### PR TITLE
Product edit screen: the order page's shape, and the saves that silently did nothing

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2827,6 +2827,8 @@ button.minn-chip.sel[data-tagchip]:hover { border-color: var(--red); color: var(
    until there is a picture to remove. */
 .minn-var-imageacts button[hidden] { display: none; }
 .minn-var-note { margin-top: 12px; }
+.minn-var-error { margin-top: 10px; font-size: 13px; color: var(--red); }
+.minn-var-error[hidden] { display: none; }
 .minn-pimg-foot { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 /* A group with nothing to sit beside (the short description) takes the row. */
 .minn-order-panel.wide { grid-column: 1 / -1; border-inline-end: none; }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1580,7 +1580,12 @@ button.minn-ac-item.minn-ac-add { display: flex; align-items: center; gap: 8px; 
 /* Upload readout: which file, how far, and where it sits in the batch. Outside
    the drop zone on purpose — the zone dims while it is busy, and the one thing
    worth reading must not dim with it. */
-.minn-upl { margin: 0 0 10px; padding: 9px 12px; border: 1px solid var(--border2); border-radius: 10px; background: var(--panel2); }
+.minn-upl {
+  /* Same gutters and inner padding as .minn-picker-drop above it, so the two
+     read as one stack rather than a full-bleed strip under an inset box. */
+  margin: 10px 18px 0; padding: 14px 16px;
+  border: 1px solid var(--border2); border-radius: 11px; background: var(--panel2);
+}
 .minn-upl-row { display: flex; align-items: center; gap: 10px; font-size: 13px; color: var(--text2); }
 .minn-upl-row > .minn-cell-clip { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .minn-upl-pct { flex: none; font-variant-numeric: tabular-nums; font-weight: 600; color: var(--text); }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1555,6 +1555,33 @@ select.minn-input {
 .minn-ac-item:hover, .minn-ac-item.active { background: var(--hover); }
 .minn-ac-item.current { color: var(--accent2); font-weight: 600; }
 .minn-ac-empty { padding: 7px 10px; color: var(--text3); font-size: 13px; }
+/* A row that toggles rather than picks: the tick box says whether the record
+   is already in that term, so the list is the state and not just a menu. */
+button.minn-ac-item.minn-ac-check { display: flex; align-items: center; gap: 9px; }
+.minn-check {
+  flex: none; width: 15px; height: 15px; border-radius: 4px;
+  border: 1.5px solid var(--border2); background: var(--panel2);
+  position: relative; transition: background 0.12s, border-color 0.12s;
+}
+.minn-ac-check[aria-selected="true"] .minn-check { background: var(--accent); border-color: var(--accent); }
+.minn-ac-check[aria-selected="true"] .minn-check::after {
+  content: ""; position: absolute; inset-inline-start: 4px; top: 1px;
+  width: 4px; height: 8px; border: solid #fff; border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+/* Add new sits under a divider so it reads as an action, not another row. */
+.minn-ac-foot { border-top: 1px solid var(--border); margin-top: 4px; padding-top: 4px; }
+button.minn-ac-item.minn-ac-add { display: flex; align-items: center; gap: 8px; color: var(--accent2); font-weight: 600; }
+.minn-ac-add svg { width: 14px; height: 14px; }
+/* A field waiting on the server says so where its chevron sits: the same
+   16px slot, so nothing moves when the answer lands. */
+.minn-ac.is-loading > .minn-ac-input { background-image: none; }
+.minn-ac.is-loading::after {
+  content: ""; position: absolute; top: 50%; inset-inline-end: 10px; margin-top: -7px;
+  width: 13px; height: 13px; border-radius: 50%;
+  border: 2px solid var(--border2); border-top-color: var(--accent);
+  animation: minnSpin 0.7s linear infinite; pointer-events: none;
+}
 /* Site icon field: preview + dropzone. */
 .minn-icon-drop {
   display: flex; align-items: center; gap: 14px; padding: 12px;

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1597,6 +1597,9 @@ select.minn-input {
   white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word;
 }
 .minn-editor-title::placeholder { color: var(--text3); }
+/* Only drawn when the reader arrived from somewhere with a trail (a product's
+   description, say), so the editor's usual look is untouched. */
+.minn-editor-back { margin-bottom: 10px; }
 /* Sticky so the formatting tools stay reachable in long posts; opaque so
    content scrolls beneath, below the fixed word-count pill (40) and chips.
    -webkit-sticky first for older iOS; solid background is load-bearing

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2687,9 +2687,25 @@ button.minn-chip.sel[data-tagchip]:hover { border-color: var(--red); color: var(
 .minn-order-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0; border-bottom: 1px solid var(--border); }
 .minn-order-panel { padding: 14px 18px 16px; border-inline-end: 1px solid var(--border); }
 .minn-order-panel:last-child { border-inline-end: none; }
-/* The product body runs to four panels. The two-panel order body needed no
-   rule between rows; a wrapped grid does, or row two floats. */
-.minn-grid-rows > .minn-order-panel:nth-child(n+3) { border-top: 1px solid var(--border); }
+/* A product with nothing for the sidebar (no edit capability: the page is a
+   summary) drops the second track rather than leaving a 340px hole. */
+.minn-order-page .minn-order-layout-solo { grid-template-columns: minmax(0, 1fr); }
+/* The product page's save bar. Absent until an edit, then pinned to the bottom
+   of the scrollport, because this page runs several screens and a button at
+   the end of it asks for a scroll before every save. sticky, not fixed: fixed
+   would leave the page's column and float over the nav. It also has to stay
+   OUT of any overflow:hidden wrapper — that wrapper would become its scroll
+   container and the bar would stick to nothing (see renderProductPage). */
+.minn-psavebar {
+	position: sticky; bottom: 0; z-index: 5;
+	display: flex; align-items: center; gap: 10px;
+	margin-top: 14px; padding: 10px 14px;
+	background: var(--panel); border: 1px solid var(--border2); border-radius: 12px;
+	box-shadow: var(--shadow);
+}
+/* display:flex would beat the hidden attribute on its own. */
+.minn-psavebar[hidden] { display: none; }
+.minn-psavebar-note { font-size: 13px; color: var(--text2); margin-inline-end: auto; }
 /* The product Images card reuses the island tile grid, inline instead of in a
    modal: the page has the room, and it saves with the rest of the form. */
 .minn-pimg-grid { margin-bottom: 10px; }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2776,16 +2776,57 @@ button.minn-chip.sel[data-tagchip]:hover { border-color: var(--red); color: var(
 .minn-pattr-flag { display: flex; align-items: center; gap: 6px; font-size: 12.5px; color: var(--text2); flex: none; }
 .minn-pattr-pick { flex: 0 1 250px; }
 @media (max-width: 720px) { .minn-pattr-name, .minn-pattr-pick { flex-basis: 100%; } }
-/* Variations: the attribute combination, then the fields that differ by it. */
-.minn-pvar-list { display: flex; flex-direction: column; gap: 7px; margin-bottom: 10px; }
-.minn-pvar-row { display: flex; gap: 7px; align-items: center; flex-wrap: wrap; }
-.minn-pvar-axes { display: flex; gap: 6px; flex: 1 1 220px; min-width: 0; }
-.minn-pvar-axis { flex: 1 1 auto; min-width: 0; }
-.minn-pvar-stock { position: relative; }
-.minn-pvar-sku { flex: 0 1 150px; min-width: 0; }
-.minn-pvar-price { flex: 0 1 92px; min-width: 0; }
-.minn-pvar-stock { flex: 0 1 150px; min-width: 0; }
-@media (max-width: 720px) { .minn-pvar-axes, .minn-pvar-sku, .minn-pvar-stock { flex-basis: 100%; } }
+/* Variations: a list of variants, each row a way into its editor. The row is a
+   div and not a button because it CONTAINS one (remove) — a button inside a
+   button is invalid and the browser drops the inner one. */
+.minn-pvar-list { display: flex; flex-direction: column; margin-bottom: 10px; }
+.minn-pvar-head, .minn-pvar-row {
+  display: grid; grid-template-columns: 34px minmax(0, 1fr) 110px 96px 26px;
+  gap: 10px; align-items: center;
+}
+.minn-pvar-head {
+  padding: 0 6px 6px; font-size: 12px; font-weight: 600; color: var(--text3);
+  border-bottom: 1px solid var(--border);
+}
+.minn-pvar-row {
+  padding: 8px 6px; border-bottom: 1px solid var(--border);
+  cursor: pointer; border-radius: 8px; transition: background 0.12s;
+}
+.minn-pvar-row:hover { background: var(--hover); }
+.minn-pvar-row:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+.minn-pvar-thumb {
+  width: 34px; height: 34px; border-radius: 7px; overflow: hidden;
+  display: flex; align-items: center; justify-content: center;
+  background: var(--panel2); border: 1px solid var(--border); color: var(--text3);
+}
+.minn-pvar-thumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.minn-pvar-thumb svg { width: 15px; height: 15px; }
+.minn-pvar-name { display: flex; align-items: center; gap: 8px; font-size: 13.5px; }
+.minn-pvar-new {
+  flex: none; padding: 1px 7px; border-radius: 999px; font-size: 11px; font-weight: 600;
+  color: var(--accent2); background: var(--accent-soft);
+}
+.minn-pvar-price, .minn-pvar-avail { font-size: 13px; font-variant-numeric: tabular-nums; color: var(--text2); }
+.minn-pvar-price .minn-prod-was { font-size: 11.5px; }
+@media (max-width: 720px) {
+  .minn-pvar-head { display: none; }
+  .minn-pvar-row { grid-template-columns: 34px minmax(0, 1fr) 26px; }
+  .minn-pvar-row > .minn-pvar-price, .minn-pvar-row > .minn-pvar-avail { display: none; }
+}
+/* The variant editor: one variant, everything about it. */
+.minn-var-fields { margin: 14px 0 4px; }
+.minn-var-imagerow { display: flex; align-items: center; gap: 12px; }
+.minn-var-image {
+  width: 64px; height: 64px; flex: none; border-radius: 10px; overflow: hidden;
+  display: flex; align-items: center; justify-content: center;
+  background: var(--panel2); border: 1px solid var(--border); color: var(--text3);
+}
+.minn-var-image img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.minn-var-imageacts { display: flex; flex-direction: column; gap: 6px; align-items: flex-start; }
+/* A button's own display beats [hidden], so Remove needs this to stay away
+   until there is a picture to remove. */
+.minn-var-imageacts button[hidden] { display: none; }
+.minn-var-note { margin-top: 12px; }
 .minn-pimg-foot { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 /* A group with nothing to sit beside (the short description) takes the row. */
 .minn-order-panel.wide { grid-column: 1 / -1; border-inline-end: none; }
@@ -3032,6 +3073,10 @@ button.minn-ac-item.minn-of-item { display: flex; align-items: center; gap: 8px;
 
 /* Shared confirm modal — scope disclosure + typed confirmation */
 .minn-confirm-overlay { z-index: 90; }
+/* The media picker is always the topmost thing while it is open: it is a leaf
+   interaction, and it can be opened FROM a dialog (a variant's image), which
+   sits at 90. Anything below this would open behind the dialog that asked. */
+.minn-picker-over { z-index: 95; }
 .minn-confirm-modal { width: 440px; max-width: 92vw; padding: 20px 22px; }
 .minn-confirm-title { font-size: 16.5px; font-weight: 700; margin-bottom: 8px; }
 .minn-confirm-body { font-size: 13.5px; color: var(--text2); line-height: 1.55; }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1573,6 +1573,10 @@ button.minn-ac-item.minn-ac-check { display: flex; align-items: center; gap: 9px
 .minn-ac-foot { border-top: 1px solid var(--border); margin-top: 4px; padding-top: 4px; }
 button.minn-ac-item.minn-ac-add { display: flex; align-items: center; gap: 8px; color: var(--accent2); font-weight: 600; }
 .minn-ac-add svg { width: 14px; height: 14px; }
+/* The Add-a-term dialog: minnConfirm's shell with a form in it. */
+.minn-term-fields { margin: 14px 0 4px; }
+.minn-term-error { margin-top: 10px; font-size: 13px; color: var(--red); }
+.minn-term-error[hidden] { display: none; }
 /* Upload readout: which file, how far, and where it sits in the batch. Outside
    the drop zone on purpose — the zone dims while it is busy, and the one thing
    worth reading must not dim with it. */

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1573,6 +1573,16 @@ button.minn-ac-item.minn-ac-check { display: flex; align-items: center; gap: 9px
 .minn-ac-foot { border-top: 1px solid var(--border); margin-top: 4px; padding-top: 4px; }
 button.minn-ac-item.minn-ac-add { display: flex; align-items: center; gap: 8px; color: var(--accent2); font-weight: 600; }
 .minn-ac-add svg { width: 14px; height: 14px; }
+/* Upload readout: which file, how far, and where it sits in the batch. Outside
+   the drop zone on purpose — the zone dims while it is busy, and the one thing
+   worth reading must not dim with it. */
+.minn-upl { margin: 0 0 10px; padding: 9px 12px; border: 1px solid var(--border2); border-radius: 10px; background: var(--panel2); }
+.minn-upl-row { display: flex; align-items: center; gap: 10px; font-size: 13px; color: var(--text2); }
+.minn-upl-row > .minn-cell-clip { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.minn-upl-pct { flex: none; font-variant-numeric: tabular-nums; font-weight: 600; color: var(--text); }
+.minn-upl-bar { margin-top: 7px; height: 4px; border-radius: 3px; background: var(--border); overflow: hidden; }
+.minn-upl-bar > span { display: block; height: 100%; background: var(--accent); border-radius: 3px; transition: width 0.15s ease; }
+.minn-upl-count { margin-top: 6px; font-size: 12px; color: var(--text3); }
 /* A field waiting on the server says so where its chevron sits: the same
    16px slot, so nothing moves when the answer lands. */
 .minn-ac.is-loading > .minn-ac-input { background-image: none; }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -8823,6 +8823,10 @@
 			regular_price: v.regular_price || '',
 			sale_price: v.sale_price || '',
 			stock_status: v.stock_status || 'instock',
+			manage_stock: !! v.manage_stock,
+			// null is "not tracked", which is not the same as none left.
+			stock_quantity: v.stock_quantity == null ? null : v.stock_quantity,
+			image: v.image && v.image.id ? { id: v.image.id, src: v.image.src || '' } : null,
 			attributes: ( v.attributes || [] ).map( ( a ) => ( { id: a.id || 0, name: a.name || '', option: a.option || '' } ) ),
 		} ) );
 		m.variationsRemoved = [];
@@ -8842,6 +8846,33 @@
 		} ).join( ' · ' );
 	}
 
+	/**
+	 * The Variations card is a list of variants, not a grid of inputs: name,
+	 * picture, price and what is available, with everything modifiable behind
+	 * the row (openVariationDialog). Six variants of five fields each was 30
+	 * boxes on screen and no way to see, at a glance, what the product sells.
+	 */
+	function variationRowHtml( m, v, i ) {
+		const label = variationLabel( m, v );
+		const price = v.sale_price
+			? `$${ esc( v.sale_price ) }<span class="minn-prod-was">$${ esc( v.regular_price || '' ) }</span>`
+			: ( v.regular_price ? `$${ esc( v.regular_price ) }` : '—' );
+		// Available means a number only when the variant tracks stock; the
+		// status is the honest answer otherwise, and it is what WooCommerce
+		// itself falls back to.
+		const avail = v.manage_stock
+			? esc( String( v.stock_quantity == null ? 0 : v.stock_quantity ) )
+			: esc( ( { instock: __( 'In stock' ), outofstock: __( 'Out of stock' ), onbackorder: __( 'On backorder' ) } )[ v.stock_status ] || __( 'In stock' ) );
+		return `
+			<div class="minn-pvar-row" data-pvaropen="${ i }" role="button" tabindex="0" aria-label="${ esc( sprintf( /* translators: %s: the variation label, for example "Large / Blue". */ __( 'Edit variation %s' ), label ) ) }">
+				<span class="minn-pvar-thumb">${ v.image && v.image.src ? `<img src="${ esc( v.image.src ) }" alt="" loading="lazy">` : icon( 'img' ) }</span>
+				<span class="minn-pvar-name minn-cell-clip">${ esc( label ) }${ v.id ? '' : `<span class="minn-pvar-new">${ esc( __( 'New' ) ) }</span>` }</span>
+				<span class="minn-pvar-price">${ price }</span>
+				<span class="minn-pvar-avail">${ avail }</span>
+				<button type="button" class="minn-pdl-x" data-pvarx="${ i }" title="${ esc( __( 'Remove' ) ) }" aria-label="${ esc( sprintf( /* translators: %s: the variation label, for example "Large / Blue". */ __( 'Remove variation %s' ), label ) ) }">×</button>
+			</div>`;
+	}
+
 	function productVariationsHtml( m ) {
 		const axes = variationAxes( m );
 		if ( ! axes.length ) {
@@ -8850,28 +8881,162 @@
 		if ( ! ( m.variations || [] ).length ) {
 			return `<div class="minn-pdl-empty">${ esc( __( 'No variations yet. Generate them from the attributes, or add one at a time.' ) ) }</div>`;
 		}
-		return m.variations.map( ( v, i ) => `
-			<div class="minn-pvar-row">
-				<div class="minn-pvar-axes">
-					${ axes.map( ( a, ai ) => {
-						const hit = ( v.attributes || [] ).find( ( x ) => ( a.id ? x.id === a.id : x.name === a.name ) );
-						const cur = ( hit && hit.option ) || '';
-						const anyLabel = sprintf( /* translators: %s: a product attribute name, for example Colour. */ __( 'Any %s' ), a.name );
-						return `<div class="minn-ac minn-pvar-axis" data-pvaraxis="${ i }:${ ai }">
-							<input class="minn-input minn-ac-input" value="${ esc( cur || anyLabel ) }" autocomplete="off" spellcheck="false" role="combobox" aria-expanded="false" aria-label="${ esc( a.name ) }">
+		return `
+			<div class="minn-pvar-head">
+				<span></span>
+				<span>${ esc( __( 'Variant' ) ) }</span>
+				<span>${ esc( __( 'Price' ) ) }</span>
+				<span>${ esc( __( 'Available' ) ) }</span>
+				<span></span>
+			</div>`
+			+ m.variations.map( ( v, i ) => variationRowHtml( m, v, i ) ).join( '' );
+	}
+
+	/**
+	 * One variant, everything about it, in a dialog. Cancel and Done, not a
+	 * live model: half-typed values on a row that also feeds the batch save
+	 * would reach the server on any other save, so the dialog edits a copy and
+	 * only Done writes it back. Nothing here talks to the server either way;
+	 * variations still ride the page's single Save, which is the contract
+	 * documented in woocommerce-products.md.
+	 *
+	 * Built like openTermDialog, and for the same reason: it opens over a card
+	 * that repaints under it.
+	 */
+	function openVariationDialog( m, index ) {
+		return new Promise( ( resolve ) => {
+			const src = m.variations[ index ];
+			if ( ! src ) { resolve( false ); return; }
+			// The working copy. attributes are cloned deep enough that picking
+			// an axis in the dialog cannot reach the row behind it.
+			const v = Object.assign( {}, src, {
+				attributes: ( src.attributes || [] ).map( ( a ) => Object.assign( {}, a ) ),
+				image: src.image ? Object.assign( {}, src.image ) : null,
+			} );
+			const axes = variationAxes( m );
+			const stockOptions = [
+				{ value: 'instock', label: __( 'In stock' ) },
+				{ value: 'outofstock', label: __( 'Out of stock' ) },
+				{ value: 'onbackorder', label: __( 'On backorder' ) },
+			];
+			const overlay = document.createElement( 'div' );
+			overlay.className = 'minn-modal-overlay minn-confirm-overlay';
+			overlay.id = 'minn-var-dialog';
+			const imageHtml = () => ( v.image && v.image.src
+				? `<img src="${ esc( v.image.src ) }" alt="">`
+				: icon( 'img' ) );
+			overlay.innerHTML = `
+			<div class="minn-modal minn-confirm-modal" role="dialog" aria-modal="true" aria-label="${ esc( variationLabel( m, v ) ) }">
+				<div class="minn-confirm-title">${ esc( sprintf( /* translators: %s: the variation label, for example "Large / Blue". */ __( 'Edit %s' ), variationLabel( m, v ) ) ) }</div>
+				<div class="minn-order-fields minn-var-fields">
+					<div class="minn-var-imagerow">
+						<div class="minn-var-image" id="minn-var-image">${ imageHtml() }</div>
+						<div class="minn-var-imageacts">
+							<button type="button" class="minn-btn-soft" id="minn-var-img-pick">${ esc( __( 'Choose image…' ) ) }</button>
+							<button type="button" class="minn-btn-soft" id="minn-var-img-x"${ v.image ? '' : ' hidden' }>${ esc( __( 'Remove image' ) ) }</button>
+						</div>
+					</div>
+					${ axes.length ? `<div class="minn-order-field-row">${ axes.map( ( a, ai ) => `
+						<div>
+							<div class="minn-field-label">${ esc( a.name ) }</div>
+							<div class="minn-ac" data-varaxis="${ ai }">
+								<input class="minn-input minn-ac-input" autocomplete="off" spellcheck="false" role="combobox" aria-expanded="false" aria-label="${ esc( a.name ) }">
+								<div class="minn-ac-panel" hidden></div>
+							</div>
+						</div>` ).join( '' ) }</div>` : '' }
+					<div class="minn-order-field-row">
+						<div><div class="minn-field-label">${ esc( __( 'Regular price' ) ) }</div><input class="minn-input" id="minn-var-regular" inputmode="decimal" value="${ esc( v.regular_price ) }"></div>
+						<div><div class="minn-field-label">${ esc( __( 'Sale price' ) ) }</div><input class="minn-input" id="minn-var-sale" inputmode="decimal" value="${ esc( v.sale_price ) }" placeholder="${ esc( __( 'Optional' ) ) }"></div>
+					</div>
+					<div><div class="minn-field-label">${ esc( __( 'SKU' ) ) }</div><input class="minn-input" id="minn-var-sku" value="${ esc( v.sku ) }" placeholder="${ esc( __( 'Optional' ) ) }"></div>
+					<div>
+						<div class="minn-field-label">${ esc( __( 'Stock status' ) ) }</div>
+						<div class="minn-ac" data-varstock>
+							<input class="minn-input minn-ac-input" autocomplete="off" spellcheck="false" role="combobox" aria-expanded="false" aria-label="${ esc( __( 'Stock status' ) ) }">
 							<div class="minn-ac-panel" hidden></div>
-						</div>`;
-					} ).join( '' ) }
+						</div>
+					</div>
+					${ productToggleHtml( 'minn-var-track', __( 'Track stock quantity' ), v.manage_stock ) }
+					<div id="minn-var-qty-row"${ v.manage_stock ? '' : ' hidden' }>
+						<div class="minn-field-label">${ esc( __( 'Quantity' ) ) }</div>
+						<input class="minn-input" id="minn-var-qty" type="number" step="1" value="${ v.stock_quantity == null ? '' : esc( String( v.stock_quantity ) ) }">
+					</div>
 				</div>
-				<input class="minn-input minn-pvar-sku" data-pvarsku="${ i }" value="${ esc( v.sku ) }" placeholder="${ esc( __( 'SKU' ) ) }" aria-label="${ esc( __( 'Variation SKU' ) ) }">
-				<input class="minn-input minn-pvar-price" data-pvarreg="${ i }" value="${ esc( v.regular_price ) }" inputmode="decimal" placeholder="${ esc( __( 'Price' ) ) }" aria-label="${ esc( __( 'Regular price' ) ) }">
-				<input class="minn-input minn-pvar-price" data-pvarsale="${ i }" value="${ esc( v.sale_price ) }" inputmode="decimal" placeholder="${ esc( __( 'Sale' ) ) }" aria-label="${ esc( __( 'Sale price' ) ) }">
-				<div class="minn-ac minn-pvar-stock" data-pvarstock="${ i }">
-					<input class="minn-input minn-ac-input" value="${ esc( ( { instock: __( 'In stock' ), outofstock: __( 'Out of stock' ), onbackorder: __( 'On backorder' ) } )[ v.stock_status ] || __( 'In stock' ) ) }" autocomplete="off" spellcheck="false" role="combobox" aria-expanded="false" aria-label="${ esc( __( 'Stock status' ) ) }">
-					<div class="minn-ac-panel" hidden></div>
+				<div class="minn-toggle-desc minn-var-note">${ esc( __( 'Variations save with the rest of the page.' ) ) }</div>
+				<div class="minn-confirm-actions">
+					<button class="minn-btn-soft" data-var-cancel type="button">${ esc( __( 'Cancel' ) ) }</button>
+					<button class="minn-btn-primary" data-var-done type="button">${ esc( __( 'Done' ) ) }</button>
 				</div>
-				<button type="button" class="minn-pdl-x" data-pvarx="${ i }" title="${ esc( __( 'Remove' ) ) }" aria-label="${ esc( sprintf( /* translators: %s: the variation label, for example "Large / Blue". */ __( 'Remove variation %s' ), variationLabel( m, v ) ) ) }">×</button>
-			</div>` ).join( '' );
+			</div>`;
+			document.body.appendChild( overlay );
+			const done = ( ok ) => {
+				overlay.remove();
+				document.removeEventListener( 'keydown', onKey );
+				resolve( !! ok );
+			};
+			const onKey = ( e ) => { if ( e.key === 'Escape' ) { e.stopPropagation(); done( false ); } };
+			document.addEventListener( 'keydown', onKey );
+			overlay.addEventListener( 'mousedown', ( e ) => { if ( e.target === overlay ) done( false ); } );
+			overlay.querySelector( '[data-var-cancel]' ).addEventListener( 'click', () => done( false ) );
+
+			// Comboboxes, not native selects, as everywhere else on this page.
+			$$( '[data-varaxis]', overlay ).forEach( ( wrap ) => {
+				const ai = parseInt( wrap.dataset.varaxis, 10 );
+				const a = axes[ ai ];
+				const hit = ( v.attributes || [] ).find( ( x ) => ( a.id ? x.id === a.id : x.name === a.name ) );
+				bindAutocomplete( wrap, [ { value: '', label: sprintf( /* translators: %s: a product attribute name, for example Colour. */ __( 'Any %s' ), a.name ) } ]
+					.concat( a.options.map( ( o ) => ( { value: o, label: o } ) ) ), {
+					strict: true,
+					value: ( hit && hit.option ) || '',
+					onPick: ( picked ) => {
+						v.attributes = ( v.attributes || [] ).filter( ( x ) => ( a.id ? x.id !== a.id : x.name !== a.name ) );
+						if ( picked ) v.attributes.push( { id: a.id || 0, name: a.name, option: picked } );
+					},
+				} );
+			} );
+			bindAutocomplete( overlay.querySelector( '[data-varstock]' ), stockOptions, {
+				strict: true,
+				value: v.stock_status || 'instock',
+				onPick: ( picked ) => { v.stock_status = picked; },
+			} );
+			const track = overlay.querySelector( '#minn-var-track' );
+			const qtyRow = overlay.querySelector( '#minn-var-qty-row' );
+			if ( track ) track.addEventListener( 'click', () => {
+				const on = track.classList.toggle( 'on' );
+				track.setAttribute( 'aria-checked', on ? 'true' : 'false' );
+				qtyRow.hidden = ! on;
+			} );
+
+			const imgBox = overlay.querySelector( '#minn-var-image' );
+			const imgX = overlay.querySelector( '#minn-var-img-x' );
+			const paintImage = () => {
+				imgBox.innerHTML = imageHtml();
+				imgX.hidden = ! v.image;
+			};
+			overlay.querySelector( '#minn-var-img-pick' ).addEventListener( 'click', () => {
+				openMediaPicker( ( picked ) => {
+					if ( ! picked ) return;
+					v.image = { id: picked.id, src: picked.thumb || picked.url || '' };
+					paintImage();
+				} );
+			} );
+			imgX.addEventListener( 'click', () => { v.image = null; paintImage(); } );
+
+			overlay.querySelector( '[data-var-done]' ).addEventListener( 'click', () => {
+				v.regular_price = ( overlay.querySelector( '#minn-var-regular' ).value || '' ).trim();
+				v.sale_price = ( overlay.querySelector( '#minn-var-sale' ).value || '' ).trim();
+				v.sku = ( overlay.querySelector( '#minn-var-sku' ).value || '' ).trim();
+				v.manage_stock = track.classList.contains( 'on' );
+				const raw = ( overlay.querySelector( '#minn-var-qty' ).value || '' ).trim();
+				v.stock_quantity = v.manage_stock ? ( raw === '' ? 0 : parseInt( raw, 10 ) ) : null;
+				m.variations[ index ] = v;
+				done( true );
+			} );
+			setTimeout( () => {
+				const first = overlay.querySelector( '#minn-var-regular' );
+				if ( first ) first.focus();
+			}, 30 );
+		} );
 	}
 
 	function bindProductVariations( m ) {
@@ -8883,59 +9048,47 @@
 			const gen = $( '#minn-p-var-gen' );
 			if ( gen ) gen.disabled = ! variationAxes( m ).length;
 		};
-		const setAxis = ( vi, ai, option ) => {
-			const axes = variationAxes( m );
-			const a = axes[ ai ];
-			if ( ! a ) return;
-			const v = m.variations[ vi ];
-			v.attributes = ( v.attributes || [] ).filter( ( x ) => ( a.id ? x.id !== a.id : x.name !== a.name ) );
-			if ( option ) v.attributes.push( { id: a.id || 0, name: a.name, option } );
+		const open = async ( i ) => {
+			const changed = await openVariationDialog( m, i );
+			if ( ! changed ) return;
+			repaint();
+			// The dialog is outside this card, so the save bar never saw the
+			// click that changed anything in it.
+			if ( m.syncDirty ) m.syncDirty();
 		};
 		const bindRows = () => {
-			[ [ 'pvarsku', 'sku' ], [ 'pvarreg', 'regular_price' ], [ 'pvarsale', 'sale_price' ] ].forEach( ( [ attr, key ] ) => {
-				$$( `[data-${ attr }]`, list ).forEach( ( el ) => el.addEventListener( 'input', () => {
-					m.variations[ parseInt( el.dataset[ attr ], 10 ) ][ key ] = el.value.trim();
-				} ) );
-			} );
-			// Comboboxes, not native selects, like every other choice on this
-			// page. The pick writes straight to the model, so nothing has to
-			// read a label back out of the DOM at save time.
-			$$( '[data-pvarstock]', list ).forEach( ( wrap ) => {
-				const i = parseInt( wrap.dataset.pvarstock, 10 );
-				bindAutocomplete( wrap, [
-					{ value: 'instock', label: __( 'In stock' ) },
-					{ value: 'outofstock', label: __( 'Out of stock' ) },
-					{ value: 'onbackorder', label: __( 'On backorder' ) },
-				], {
-					strict: true,
-					value: m.variations[ i ].stock_status || 'instock',
-					onPick: ( v ) => { m.variations[ i ].stock_status = v; },
+			$$( '[data-pvaropen]', list ).forEach( ( row ) => {
+				const i = parseInt( row.dataset.pvaropen, 10 );
+				row.addEventListener( 'click', ( e ) => {
+					// The remove button lives inside the row (a button inside a
+					// button is invalid markup, so the row is not one), and its
+					// click must not also open the editor.
+					if ( e.target.closest( '[data-pvarx]' ) ) return;
+					open( i );
+				} );
+				row.addEventListener( 'keydown', ( e ) => {
+					if ( e.key !== 'Enter' && e.key !== ' ' ) return;
+					e.preventDefault();
+					open( i );
 				} );
 			} );
-			$$( '[data-pvaraxis]', list ).forEach( ( wrap ) => {
-				const [ vi, ai ] = wrap.dataset.pvaraxis.split( ':' ).map( Number );
-				const a = variationAxes( m )[ ai ];
-				if ( ! a ) return;
-				const hit = ( m.variations[ vi ].attributes || [] ).find( ( x ) => ( a.id ? x.id === a.id : x.name === a.name ) );
-				bindAutocomplete( wrap, [ { value: '', label: sprintf( /* translators: %s: a product attribute name, for example Colour. */ __( 'Any %s' ), a.name ) } ]
-					.concat( a.options.map( ( o ) => ( { value: o, label: o } ) ) ), {
-					strict: true,
-					value: ( hit && hit.option ) || '',
-					onPick: ( v ) => setAxis( vi, ai, v ),
-				} );
-			} );
-			$$( '[data-pvarx]', list ).forEach( ( el ) => el.addEventListener( 'click', () => {
+			$$( '[data-pvarx]', list ).forEach( ( el ) => el.addEventListener( 'click', ( e ) => {
+				// Keeps the row underneath from opening the editor — and, with
+				// it, keeps this click from reaching the save bar's watcher,
+				// which is why the bar is told directly below.
+				e.stopPropagation();
 				const i = parseInt( el.dataset.pvarx, 10 );
 				const gone = m.variations.splice( i, 1 )[ 0 ];
 				// An id means it exists on the server and has to be deleted there.
 				if ( gone && gone.id ) m.variationsRemoved.push( gone.id );
 				repaint();
+				if ( m.syncDirty ) m.syncDirty();
 			} ) );
 		};
 		bindRows();
 		const add = $( '#minn-p-var-add' );
 		if ( add ) add.addEventListener( 'click', () => {
-			m.variations.push( { id: 0, sku: '', regular_price: '', sale_price: '', stock_status: 'instock', attributes: [] } );
+			m.variations.push( { id: 0, sku: '', regular_price: '', sale_price: '', stock_status: 'instock', manage_stock: false, stock_quantity: null, image: null, attributes: [] } );
 			repaint();
 		} );
 		// Every combination the attributes allow, minus the ones already here.
@@ -8957,7 +9110,7 @@
 			let added = 0;
 			combos.forEach( ( attrs ) => {
 				if ( have.has( keyOf( attrs ) ) ) return;
-				m.variations.push( { id: 0, sku: '', regular_price: '', sale_price: '', stock_status: 'instock', attributes: attrs } );
+				m.variations.push( { id: 0, sku: '', regular_price: '', sale_price: '', stock_status: 'instock', manage_stock: false, stock_quantity: null, image: null, attributes: attrs } );
 				added++;
 			} );
 			repaint();
@@ -8978,8 +9131,17 @@
 				regular_price: v.regular_price,
 				sale_price: v.sale_price,
 				stock_status: v.stock_status,
+				manage_stock: !! v.manage_stock,
+				// { id: 0 } is how WooCommerce is told to drop a variation's
+				// picture; verified against a live store, along with the fact
+				// that null does the same. Sending the pair explicitly keeps
+				// set and clear symmetrical.
+				image: v.image && v.image.id ? { id: v.image.id } : { id: 0 },
 				attributes: ( v.attributes || [] ).map( ( a ) => ( a.id ? { id: a.id, option: a.option } : { name: a.name, option: a.option } ) ),
 			};
+			// Only meaningful while tracking, and WooCommerce reads a null here
+			// as "stop tracking", which the switch above already said.
+			if ( v.manage_stock ) row.stock_quantity = v.stock_quantity == null ? 0 : v.stock_quantity;
 			if ( v.id ) body.update.push( Object.assign( { id: v.id }, row ) );
 			else body.create.push( row );
 		} );
@@ -9359,7 +9521,7 @@
 				// are fetched here rather than filled in after the paint.
 				let variationRows = [];
 				if ( ( full.type || '' ) === 'variable' ) {
-					variationRows = await api( `wc/v3/products/${ id }/variations?per_page=100&_fields=id,sku,regular_price,sale_price,stock_status,attributes` )
+					variationRows = await api( `wc/v3/products/${ id }/variations?per_page=100&_fields=id,sku,regular_price,sale_price,stock_status,manage_stock,stock_quantity,image,attributes` )
 						.catch( () => [] );
 				}
 				if ( ! isCur() ) return;
@@ -10542,7 +10704,7 @@
 				// re-reading them a second save would create duplicates.
 				let freshVariations = [];
 				if ( ( ( full || {} ).type || '' ) === 'variable' ) {
-					freshVariations = await api( `wc/v3/products/${ p.id }/variations?per_page=100&_fields=id,sku,regular_price,sale_price,stock_status,attributes` )
+					freshVariations = await api( `wc/v3/products/${ p.id }/variations?per_page=100&_fields=id,sku,regular_price,sale_price,stock_status,manage_stock,stock_quantity,image,attributes` )
 						.catch( () => [] );
 				}
 				if ( isCur() ) {
@@ -33480,7 +33642,7 @@
 			const items = m.items;
 			const any = !! m.any;
 			return `
-			<div class="minn-modal-overlay" id="minn-modal-overlay">
+			<div class="minn-modal-overlay minn-picker-over" id="minn-modal-overlay">
 				<div class="minn-modal wide">
 					<div class="minn-modal-head">
 						<div class="minn-modal-title">${ m.multi ? esc( __( 'Build a gallery' ) ) : ( any ? esc( __( 'Insert file' ) ) : esc( __( 'Insert image' ) ) ) }</div>

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -9042,10 +9042,14 @@
 
 	// The Organization card's taxonomies. A store without brands answers with
 	// no `brands` key at all, which is how that field knows to stay away.
+	// `create` is Enter-to-create, which stays off for a hierarchy: a typo
+	// would land a stray term in a tree this field does not edit. `hierarchy`
+	// is what makes the Add dialog offer a parent. Every taxonomy can be added
+	// to from the dialog, where the name is typed on purpose.
 	const PRODUCT_TERM_FIELDS = [
-		{ key: 'categories', label: __( 'Categories' ), route: 'products/categories', create: false, placeholder: __( 'Search categories' ) },
-		{ key: 'tags', label: __( 'Tags' ), route: 'products/tags', create: true, placeholder: __( 'Search or add tags' ), addLabel: __( 'Add new tag' ) },
-		{ key: 'brands', label: __( 'Brands' ), route: 'products/brands', create: true, placeholder: __( 'Search or add brands' ), addLabel: __( 'Add new brand' ) },
+		{ key: 'categories', label: __( 'Categories' ), route: 'products/categories', create: false, hierarchy: true, placeholder: __( 'Search categories' ), addLabel: __( 'Add new category' ), newTitle: __( 'New category' ), nameLabel: __( 'Category name' ) },
+		{ key: 'tags', label: __( 'Tags' ), route: 'products/tags', create: true, placeholder: __( 'Search or add tags' ), addLabel: __( 'Add new tag' ), newTitle: __( 'New tag' ), nameLabel: __( 'Tag name' ) },
+		{ key: 'brands', label: __( 'Brands' ), route: 'products/brands', create: true, placeholder: __( 'Search or add brands' ), addLabel: __( 'Add new brand' ), newTitle: __( 'New brand' ), nameLabel: __( 'Brand name' ) },
 	];
 
 	// Downloadable files ride the model too. WooCommerce mints the id for a new
@@ -9995,13 +9999,132 @@
 			: ( rows.length
 				? rows.map( ( x ) => `<button type="button" class="minn-ac-item minn-ac-check" role="option" aria-selected="${ chosen.has( x.id ) ? 'true' : 'false' }" data-ptpick="${ x.id }" data-ptname="${ esc( x.name ) }"><span class="minn-check" aria-hidden="true"></span><span class="minn-cell-clip">${ esc( x.name ) }</span></button>` ).join( '' )
 				: `<div class="minn-ac-empty">${ t.create ? esc( __( 'No matches. Press Enter to create it.' ) ) : esc( __( 'No matches' ) ) }</div>` );
-		// Creating from the list is for flat taxonomies only. A category is a
-		// place in a hierarchy, and a typo would leave junk in a tree this
-		// field is not editing (the Terms manager and WooCommerce own that).
-		const foot = t.create
-			? `<div class="minn-ac-foot"><button type="button" class="minn-ac-item minn-ac-add" data-ptadd>${ icon( 'plus' ) }<span>${ esc( t.addLabel || __( 'Add new' ) ) }</span></button></div>`
-			: '';
+		// Every taxonomy can be added to from here, hierarchy included: the
+		// dialog behind this asks for the name (and the parent) on purpose,
+		// which is the deliberate step Enter-to-create never had.
+		const foot = `<div class="minn-ac-foot"><button type="button" class="minn-ac-item minn-ac-add" data-ptadd>${ icon( 'plus' ) }<span>${ esc( t.addLabel || __( 'Add new' ) ) }</span></button></div>`;
 		return body + foot;
+	}
+
+	/**
+	 * The dialog behind a taxonomy field's Add new. A term is made from a name
+	 * typed in a dialog, which is the deliberate step that makes offering this
+	 * for CATEGORIES reasonable: Enter-to-create still refuses a hierarchy,
+	 * because a stray branch from a typo is not something this field cleans up.
+	 * A hierarchy also gets a parent, fetched when the dialog opens.
+	 *
+	 * Built like minnConfirm: its own overlay on document.body (it opens over a
+	 * panel that closes on blur, so it cannot live inside it), Escape peels
+	 * exactly one layer, and the backdrop cancels. Resolves with the new term,
+	 * or null if the reader backed out.
+	 */
+	function openTermDialog( t, presetName ) {
+		return new Promise( ( resolve ) => {
+			const overlay = document.createElement( 'div' );
+			overlay.className = 'minn-modal-overlay minn-confirm-overlay';
+			overlay.id = 'minn-term-dialog';
+			overlay.innerHTML = `
+			<div class="minn-modal minn-confirm-modal" role="dialog" aria-modal="true" aria-label="${ esc( t.newTitle || __( 'New term' ) ) }">
+				<div class="minn-confirm-title">${ esc( t.newTitle || __( 'New term' ) ) }</div>
+				<div class="minn-order-fields minn-term-fields">
+					<div>
+						<div class="minn-field-label">${ esc( t.nameLabel || __( 'Name' ) ) }</div>
+						<input class="minn-input" id="minn-term-name" autocomplete="off" spellcheck="false" value="${ esc( presetName || '' ) }">
+					</div>
+					${ t.hierarchy ? `
+					<div>
+						<div class="minn-field-label">${ esc( __( 'Parent' ) ) }</div>
+						<div class="minn-ac" data-termparent>
+							<input class="minn-input minn-ac-input" placeholder="${ esc( __( 'Top level' ) ) }" autocomplete="off" spellcheck="false" aria-label="${ esc( __( 'Parent' ) ) }">
+							<div class="minn-ac-panel" hidden></div>
+						</div>
+					</div>` : '' }
+				</div>
+				<div class="minn-term-error" hidden></div>
+				<div class="minn-confirm-actions">
+					<button class="minn-btn-soft" data-term-cancel type="button">${ esc( __( 'Cancel' ) ) }</button>
+					<button class="minn-btn-primary" data-term-create type="button">${ esc( __( 'Create' ) ) }</button>
+				</div>
+			</div>`;
+			document.body.appendChild( overlay );
+			const nameInput = overlay.querySelector( '#minn-term-name' );
+			const errBox = overlay.querySelector( '.minn-term-error' );
+			const okBtn = overlay.querySelector( '[data-term-create]' );
+			let parentId = 0;
+			const done = ( val ) => {
+				overlay.remove();
+				document.removeEventListener( 'keydown', onKey );
+				resolve( val );
+			};
+			// stopPropagation: this sits over a page (and sometimes a modal)
+			// whose own Escape handlers would otherwise close the layer under
+			// it from the same keypress.
+			const onKey = ( e ) => { if ( e.key === 'Escape' ) { e.stopPropagation(); done( null ); } };
+			document.addEventListener( 'keydown', onKey );
+			overlay.addEventListener( 'mousedown', ( e ) => { if ( e.target === overlay ) done( null ); } );
+			overlay.querySelector( '[data-term-cancel]' ).addEventListener( 'click', () => done( null ) );
+
+			const parentWrap = overlay.querySelector( '[data-termparent]' );
+			if ( parentWrap ) {
+				const pInput = parentWrap.querySelector( '.minn-ac-input' );
+				const pPanel = parentWrap.querySelector( '.minn-ac-panel' );
+				let loaded = null;
+				const paint = () => {
+					const rows = loaded == null
+						? `<div class="minn-ac-empty">${ esc( __( 'Searching…' ) ) }</div>`
+						: `<button type="button" class="minn-ac-item" data-parent="0">${ esc( __( 'Top level' ) ) }</button>`
+							+ loaded.map( ( x ) => `<button type="button" class="minn-ac-item" data-parent="${ x.id }">${ esc( x.name ) }</button>` ).join( '' );
+					pPanel.innerHTML = rows;
+					pPanel.hidden = false;
+					$$( '[data-parent]', pPanel ).forEach( ( b ) => b.addEventListener( 'mousedown', ( e ) => {
+						e.preventDefault();
+						parentId = parseInt( b.dataset.parent, 10 ) || 0;
+						pInput.value = parentId ? b.textContent.trim() : '';
+						pPanel.hidden = true;
+					} ) );
+				};
+				pInput.addEventListener( 'focus', async () => {
+					if ( loaded ) { paint(); return; }
+					parentWrap.classList.add( 'is-loading' );
+					paint();
+					try {
+						const items = await api( `wc/v3/${ t.route }?per_page=100&orderby=name&order=asc&_fields=id,name` );
+						loaded = ( Array.isArray( items ) ? items : [] ).map( ( x ) => ( { id: x.id, name: decodeEntities( x.name || '' ) } ) );
+					} catch ( e ) {
+						loaded = [];
+					}
+					parentWrap.classList.remove( 'is-loading' );
+					paint();
+				} );
+				pInput.addEventListener( 'blur', () => setTimeout( () => { pPanel.hidden = true; }, 150 ) );
+			}
+
+			const submit = async () => {
+				const name = nameInput.value.trim();
+				if ( ! name ) { nameInput.focus(); return; }
+				okBtn.disabled = true;
+				okBtn.textContent = __( 'Creating…' );
+				errBox.hidden = true;
+				try {
+					const payload = { name };
+					if ( t.hierarchy && parentId ) payload.parent = parentId;
+					const made = await api( `wc/v3/${ t.route }`, { method: 'POST', body: JSON.stringify( payload ) } );
+					done( { id: made.id, name: decodeEntities( made.name || name ) } );
+				} catch ( e ) {
+					// WooCommerce owns the refusals here (a duplicate name is
+					// the common one) and says it better than we would.
+					errBox.textContent = e.message;
+					errBox.hidden = false;
+					okBtn.disabled = false;
+					okBtn.textContent = __( 'Create' );
+				}
+			};
+			okBtn.addEventListener( 'click', submit );
+			nameInput.addEventListener( 'keydown', ( e ) => {
+				if ( e.key === 'Enter' ) { e.preventDefault(); submit(); }
+			} );
+			setTimeout( () => nameInput.focus(), 30 );
+		} );
 	}
 
 	/**
@@ -10082,7 +10205,22 @@
 					toggle( { id: parseInt( b.dataset.ptpick, 10 ), name: b.dataset.ptname } );
 				} ) );
 				const addBtn = $( '[data-ptadd]', panel );
-				if ( addBtn ) addBtn.addEventListener( 'mousedown', ( e ) => { e.preventDefault(); create(); } );
+				if ( addBtn ) addBtn.addEventListener( 'mousedown', ( e ) => {
+					e.preventDefault();
+					// Whatever is half-typed in the field is the name offered,
+					// so Add new after typing is not a second round of typing.
+					openTermDialog( t, input.value.trim() ).then( ( made ) => {
+						if ( ! made ) { input.focus( { preventScroll: true } ); return; }
+						if ( Array.isArray( cache[ t.key ] ) ) cache[ t.key ].unshift( made );
+						if ( ! m.terms[ t.key ].some( ( x ) => x.id === made.id ) ) m.terms[ t.key ].push( made );
+						input.value = '';
+						repaintChips();
+						// Reopen on the plain list: the new term is in it, and
+						// ticked, which is the confirmation that it landed.
+						load( '' );
+						input.focus( { preventScroll: true } );
+					} );
+				} );
 			};
 			const load = async ( q ) => {
 				const mine = ++seq;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -33254,8 +33254,10 @@
 					${ B.caps.upload && ! any ? `
 					<div class="minn-picker-drop" id="minn-picker-drop">
 						${ icon( 'img' ) }
-						<span>${ sprintf( esc( /* translators: %s: a "browse" link. */ __( 'Drag & drop an image here, or %s' ) ), `<b>${ esc( __( 'browse' ) ) }</b>` ) }${ m.multi ? '' : ' ' + esc( __( '(it’s used right away)' ) ) }</span>
-						<input type="file" id="minn-picker-file" accept="image/*" hidden>
+						<span>${ m.multi
+							? sprintf( esc( /* translators: %s: a "browse" link. */ __( 'Drag & drop images here, or %s' ) ), `<b>${ esc( __( 'browse' ) ) }</b>` )
+							: sprintf( esc( /* translators: %s: a "browse" link. */ __( 'Drag & drop an image here, or %s' ) ), `<b>${ esc( __( 'browse' ) ) }</b>` ) + ' ' + esc( __( '(it’s used right away)' ) ) }</span>
+						<input type="file" id="minn-picker-file" accept="image/*"${ m.multi ? ' multiple' : '' } hidden>
 					</div>` : '' }
 					${ items == null ? `<div class="minn-loading">${ esc( any ? __( 'Loading files…' ) : __( 'Loading images…' ) ) }</div>` : ! items.length ? `<div class="minn-empty">${ esc( any ? __( 'No files in the library yet.' ) : __( 'No images in the library yet.' ) ) }</div>` : `
 					<div class="minn-picker-grid${ any ? ' any' : '' }">
@@ -34003,43 +34005,66 @@
 			const drop = $( '#minn-picker-drop' );
 			if ( drop ) {
 				const fileInput = $( '#minn-picker-file' );
-				const uploadAndUse = async ( file ) => {
-					if ( ! file || ! file.type.startsWith( 'image/' ) ) { toast( __( 'Drop an image file' ), true ); return; }
+				const uploadOne = async ( file ) => {
+					const fd = new FormData();
+					fd.append( 'file', file );
+					const up = await api( 'wp/v2/media', { method: 'POST', body: fd } );
+					state.cache.media = null; // library changed
+					const sizes = up.media_details && up.media_details.sizes;
+					return {
+						id: up.id,
+						name: decodeEntities( ( up.title && up.title.rendered ) || file.name ),
+						url: up.source_url,
+						alt: up.alt_text || '',
+						thumb: ( sizes && sizes.medium && sizes.medium.source_url ) || up.source_url,
+						large: ( sizes && sizes.large && sizes.large.source_url ) || up.source_url,
+					};
+				};
+				/**
+				 * Building a gallery is a several-files-at-once job, so the
+				 * whole selection uploads, not files[0]. Sequentially, not with
+				 * Promise.all: a dozen parallel uploads is how a shared host
+				 * answers 503, and the order of the picks is the gallery's
+				 * order. A single-pick picker still takes the first file only,
+				 * because it hands its one result back and closes.
+				 */
+				const uploadAndUse = async ( files ) => {
+					const list = Array.from( files || [] ).filter( ( f ) => f && f.type.startsWith( 'image/' ) );
+					if ( ! list.length ) { toast( __( 'Drop an image file' ), true ); return; }
 					drop.classList.add( 'minn-busy' );
 					toast( __( 'Uploading…' ) );
 					try {
-						const fd = new FormData();
-						fd.append( 'file', file );
-						const up = await api( 'wp/v2/media', { method: 'POST', body: fd } );
-						state.cache.media = null; // library changed
-						const sizes = up.media_details && up.media_details.sizes;
-						const it = {
-							id: up.id,
-							name: decodeEntities( ( up.title && up.title.rendered ) || file.name ),
-							url: up.source_url,
-							alt: up.alt_text || '',
-							thumb: ( sizes && sizes.medium && sizes.medium.source_url ) || up.source_url,
-							large: ( sizes && sizes.large && sizes.large.source_url ) || up.source_url,
-						};
-						if ( m.multi ) {
-							// Add to the gallery selection and keep picking.
-							m.items.unshift( it );
-							m.picked.push( it.id );
-							renderOverlays();
-							toast( __( 'Image uploaded and selected' ) );
+						if ( ! m.multi ) {
+							const it = await uploadOne( list[ 0 ] );
+							const cb = m.callback;
+							closeModal();
+							if ( cb ) cb( it );
+							toast( __( 'Image uploaded' ) );
 							return;
 						}
-						const cb = m.callback;
-						closeModal();
-						if ( cb ) cb( it );
-						toast( __( 'Image uploaded' ) );
+						let done = 0;
+						for ( const file of list ) {
+							const it = await uploadOne( file );
+							// Newest first, and picked, so the gallery grows in
+							// the order the files were handed over.
+							m.items.unshift( it );
+							m.picked.push( it.id );
+							done++;
+							renderOverlays();
+							// The re-render replaced the zone, so the busy mark
+							// goes back on the new one while files remain.
+							const zone = $( '#minn-picker-drop' );
+							if ( zone && done < list.length ) zone.classList.add( 'minn-busy' );
+						}
+						/* translators: %d: number of images uploaded. */
+						toast( sprintf( _n( '%d image uploaded and selected', '%d images uploaded and selected', done ), done ) );
 					} catch ( e ) {
 						toast( e.message, true );
 						drop.classList.remove( 'minn-busy' );
 					}
 				};
 				drop.addEventListener( 'click', () => fileInput.click() );
-				fileInput.addEventListener( 'change', () => uploadAndUse( fileInput.files && fileInput.files[ 0 ] ) );
+				fileInput.addEventListener( 'change', () => uploadAndUse( fileInput.files ) );
 				// stopPropagation keeps the app-wide drop-to-media-library handler out of it.
 				drop.addEventListener( 'dragover', ( e ) => { e.preventDefault(); e.stopPropagation(); drop.classList.add( 'over' ); } );
 				drop.addEventListener( 'dragleave', () => drop.classList.remove( 'over' ) );
@@ -34048,7 +34073,7 @@
 					e.stopPropagation();
 					drop.classList.remove( 'over' );
 					document.body.classList.remove( 'minn-dragging' );
-					uploadAndUse( e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files[ 0 ] );
+					uploadAndUse( e.dataTransfer && e.dataTransfer.files );
 				} );
 			}
 		}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -9075,6 +9075,9 @@
 		const repaint = () => {
 			list.innerHTML = productDownloadsHtml( m.downloads );
 			bindRows();
+			// Files can arrive from the media picker, which is a modal over
+			// the page: same blind spot as the images grid.
+			if ( m.syncDirty ) m.syncDirty();
 		};
 		const bindRows = () => {
 			$$( '[data-pdlname]', list ).forEach( ( el ) => el.addEventListener( 'input', () => {
@@ -9358,6 +9361,13 @@
 				if ( ! isCur() ) return;
 				m.full = full;
 				m.loading = false;
+				// Discard needs the product as it arrived, and m.full is not
+				// that: flipping the type harvests the form into it, on
+				// purpose. So keep a copy nobody writes to, plus the two
+				// side-loads the seeds need to rebuild from it.
+				m.loaded = JSON.parse( JSON.stringify( full ) );
+				m.loadedVariations = variationRows;
+				m.linkNames = names;
 				seedProductTerms( m );
 				seedProductImages( m );
 				seedProductDownloads( m );
@@ -9403,9 +9413,6 @@
 		const priceOk = productPriceEditable( p );
 		const cats = ( p.categories || [] ).map( ( c ) => c.name ).filter( Boolean ).join( ', ' );
 		const thumb = p.images && p.images[ 0 ] ? ( p.images[ 0 ].src || p.images[ 0 ].thumbnail || '' ) : '';
-		const stockOpts = [ [ 'instock', __( 'In stock' ) ], [ 'outofstock', __( 'Out of stock' ) ], [ 'onbackorder', __( 'On backorder' ) ] ];
-		const visOpts = [ [ 'visible', __( 'Shop and search results' ) ], [ 'catalog', __( 'Shop only' ) ], [ 'search', __( 'Search results only' ) ], [ 'hidden', 'Hidden' ] ];
-		const statusOpts = [ [ 'publish', 'Published' ], [ 'draft', 'Draft' ], [ 'private', 'Private' ], [ 'pending', __( 'Pending review' ) ] ];
 		const combos = productComboSpecs( p );
 		const combo = ( id ) => productComboHtml( combos.find( ( c ) => c.id === id ) );
 		const dims = p.dimensions || {};
@@ -9416,29 +9423,43 @@
 		const isExternal = ( p.type || 'simple' ) === 'external';
 		// A downloadable product carries its files; nothing else does.
 		const isDownloadable = !! p.downloadable;
-		return `
-					<div class="minn-order-body">
-						<div class="minn-order-grid minn-grid-rows">
-							<div class="minn-order-panel">
+		// Shopify's split, and the reason it reads well: the main column is what
+		// the product IS (name, pictures, price, stock, size), the sidebar is
+		// what it is FILED UNDER (published or not, type, taxonomies, links).
+		// Both are one flat list of cards. The two-column grid belongs to the
+		// PAGE's stylesheet, so the quick-view modal takes this same markup and
+		// stacks it — one body, two hosts, as on an order.
+		// data-pcard names a card so a test can assert where it is drawn rather
+		// than where it sits in the markup.
+		const card = ( key, title, inner ) => `
+							<div class="minn-order-sec" data-pcard="${ esc( key ) }">
+								<div class="minn-order-card-head"><div class="minn-side-title">${ esc( title ) }</div></div>
+								${ inner }
+							</div>`;
+		const main = `
+							${ card( 'basics', __( 'Basics' ), `
 								${ canEdit ? '' : ( thumb ? `<div class="minn-prod-modal-img"><img src="${ esc( thumb ) }" alt=""></div>` : '' ) }
-								<div class="minn-side-title" style="margin:0 0 8px;">${ esc( __( 'Basics' ) ) }</div>
 								${ canEdit ? `
 								<div class="minn-order-fields">
 									<div><div class="minn-field-label">${ esc( __( 'Name' ) ) }</div><input class="minn-input" id="minn-p-name" value="${ esc( p.name || '' ) }"></div>
-									${ combo( 'minn-p-type' ) }
-									${ productToggleHtml( 'minn-p-virtual', __( 'Virtual' ), !! p.virtual ) }
-									${ productToggleHtml( 'minn-p-downloadable', __( 'Downloadable' ), !! p.downloadable ) }
-									${ combo( 'minn-p-status' ) }
-									${ combo( 'minn-p-vis' ) }
+									<div>
+										<div class="minn-field-label">${ esc( __( 'Short description' ) ) }</div>
+										<textarea class="minn-input" id="minn-p-short" rows="3" placeholder="${ esc( __( 'Shown near the price in the shop…' ) ) }">${ esc( wcPlainText( p.short_description ) ) }</textarea>
+										<div class="minn-toggle-desc" style="margin-top:6px;">${ esc( __( "Plain text summary. The full description, with blocks and images, opens in Minn's editor." ) ) }</div>
+									</div>
 								</div>` : `
 								<div class="minn-modal-meta" style="padding:0;">
 									<div class="minn-side-row"><span class="minn-side-key">${ esc( __( 'Name' ) ) }</span><span>${ esc( p.name || '' ) }</span></div>
 									${ p.sku ? `<div class="minn-side-row"><span class="minn-side-key">${ esc( __( 'SKU' ) ) }</span><span>${ esc( p.sku ) }</span></div>` : '' }
 									${ cats ? `<div class="minn-side-row"><span class="minn-side-key">${ esc( __( 'Categories' ) ) }</span><span>${ esc( cats ) }</span></div>` : '' }
-								</div>` }
-							</div>
-							<div class="minn-order-panel">
-								<div class="minn-side-title" style="margin:0 0 8px;">${ esc( __( 'Pricing' ) ) }</div>
+								</div>` }` ) }
+							${ canEdit ? card( 'media', __( 'Images' ), `
+								<div class="minn-imgedit-grid minn-pimg-grid" id="minn-p-images">${ productImagesGridHtml( m.images || [] ) }</div>
+								<div class="minn-pimg-foot">
+									<button type="button" class="minn-btn-soft" id="minn-p-img-add">${ esc( __( 'Add images…' ) ) }</button>
+									<span class="minn-toggle-desc">${ esc( __( 'The first image is the product image, the rest are the gallery. Drag a tile to reorder, click one to replace it.' ) ) }</span>
+								</div>` ) : '' }
+							${ card( 'pricing', __( 'Pricing' ), `
 								${ canEdit && priceOk ? `
 								<div class="minn-order-fields">
 									<div class="minn-order-field-row">
@@ -9463,20 +9484,8 @@
 									<div class="minn-side-row"><span class="minn-side-key">${ esc( __( 'Price' ) ) }</span><span>${ productPriceLabel( p ) }</span></div>
 									<div class="minn-side-row"><span class="minn-side-key">${ esc( __( 'Stock' ) ) }</span><span>${ esc( productStockLabel( p ) ) }</span></div>
 									${ ! priceOk ? `<div class="minn-toggle-desc" style="margin-top:8px;">${ p.type ? sprintf( /* translators: %s: the localized product type (e.g. "Variable product"). */ esc( __( 'Price and stock for %s products are managed in WooCommerce (variations or grouped children).' ) ), esc( productTypeLabel( p.type ) ) ) : esc( __( 'Price and stock for this type of product are managed in WooCommerce (variations or grouped children).' ) ) }</div>` : '' }
-								</div>` }
-							</div>
-							${ canEdit ? `
-							<div class="minn-order-panel wide">
-								<div class="minn-side-title" style="margin:0 0 8px;">${ esc( __( 'Images' ) ) }</div>
-								<div class="minn-imgedit-grid minn-pimg-grid" id="minn-p-images">${ productImagesGridHtml( m.images || [] ) }</div>
-								<div class="minn-pimg-foot">
-									<button type="button" class="minn-btn-soft" id="minn-p-img-add">${ esc( __( 'Add images…' ) ) }</button>
-									<span class="minn-toggle-desc">${ esc( __( 'The first image is the product image, the rest are the gallery. Drag a tile to reorder, click one to replace it.' ) ) }</span>
-								</div>
-							</div>` : '' }
-							${ canEdit ? `
-							<div class="minn-order-panel">
-								<div class="minn-side-title" style="margin:0 0 8px;">${ esc( __( 'Inventory' ) ) }</div>
+								</div>` }` ) }
+							${ canEdit ? card( 'inventory', __( 'Inventory' ), `
 								<div class="minn-order-fields">
 									<div class="minn-order-field-row">
 										<div><div class="minn-field-label">${ esc( __( 'SKU' ) ) }</div><input class="minn-input" id="minn-p-sku" value="${ esc( p.sku || '' ) }" placeholder="${ esc( __( 'Optional' ) ) }"></div>
@@ -9493,11 +9502,8 @@
 									</div>
 									${ combo( 'minn-p-stock' ) }` : '' }
 									${ productToggleHtml( 'minn-p-solo', __( 'Limit purchases to 1 item per order' ), p.sold_individually ) }
-								</div>
-							</div>` : '' }
-							${ canEdit && shipOk ? `
-							<div class="minn-order-panel">
-								<div class="minn-side-title" style="margin:0 0 8px;">${ esc( __( 'Shipping' ) ) }</div>
+								</div>` ) : '' }
+							${ canEdit && shipOk ? card( 'shipping', __( 'Shipping' ), `
 								<div class="minn-order-fields">
 									<div><div class="minn-field-label">${ esc( __( 'Weight' ) ) }</div><input class="minn-input" id="minn-p-weight" type="text" inputmode="decimal" value="${ esc( p.weight || '' ) }" placeholder="0"></div>
 									<div>
@@ -9510,26 +9516,8 @@
 									</div>
 									${ combo( 'minn-p-shipclass' ) }
 									<div class="minn-toggle-desc">${ esc( __( 'Units come from your WooCommerce store settings.' ) ) }</div>
-								</div>
-							</div>` : '' }
-							${ canEdit ? `
-							<div class="minn-order-panel">
-								<div class="minn-side-title" style="margin:0 0 8px;">${ esc( __( 'Organization' ) ) }</div>
-								<div class="minn-order-fields">
-									${ PRODUCT_TERM_FIELDS.map( ( t ) => productTermFieldHtml( m, t ) ).join( '' ) }
-									<div><div class="minn-field-label">${ esc( __( 'Slug' ) ) }</div>
-										<div class="minn-slug-field">
-											<span class="minn-slug-prefix">/</span>
-											<input class="minn-input minn-slug-input" id="minn-p-slug" value="${ esc( p.slug || '' ) }" placeholder="${ esc( __( 'set-on-save' ) ) }" autocomplete="off" spellcheck="false">
-										</div>
-										${ p.status === 'publish' ? `<div class="minn-slug-note">${ esc( __( 'Changing this breaks the current URL.' ) ) }</div>` : '' }
-									</div>
-									${ productToggleHtml( 'minn-p-featured', __( 'Featured product' ), p.featured ) }
-								</div>
-							</div>` : '' }
-							${ canEdit && isDownloadable ? `
-							<div class="minn-order-panel wide">
-								<div class="minn-side-title" style="margin:0 0 8px;">${ esc( __( 'Downloads' ) ) }</div>
+								</div>` ) : '' }
+							${ canEdit && isDownloadable ? card( 'downloads', __( 'Downloads' ), `
 								<div class="minn-pdl-list" id="minn-p-downloads">${ productDownloadsHtml( m.downloads || [] ) }</div>
 								<div class="minn-pimg-foot">
 									<button type="button" class="minn-btn-soft" id="minn-p-dl-add">${ esc( __( 'Add file' ) ) }</button>
@@ -9538,23 +9526,8 @@
 								<div class="minn-order-field-row" style="margin-top:12px;">
 									<div><div class="minn-field-label">${ esc( __( 'Download limit' ) ) }</div><input class="minn-input" id="minn-p-dllimit" type="number" step="1" min="-1" value="${ p.download_limit != null && p.download_limit >= 0 ? esc( String( p.download_limit ) ) : '' }" placeholder="${ esc( __( 'Unlimited' ) ) }"></div>
 									<div><div class="minn-field-label">${ esc( __( 'Expires after (days)' ) ) }</div><input class="minn-input" id="minn-p-dlexpiry" type="number" step="1" min="-1" value="${ p.download_expiry != null && p.download_expiry >= 0 ? esc( String( p.download_expiry ) ) : '' }" placeholder="${ esc( __( 'Never' ) ) }"></div>
-								</div>
-							</div>` : '' }
-							${ canEdit ? `
-							<div class="minn-order-panel">
-								<div class="minn-side-title" style="margin:0 0 8px;">${ esc( __( 'Advanced' ) ) }</div>
-								<div class="minn-order-fields">
-									<div>
-										<div class="minn-field-label">${ esc( __( 'Purchase note' ) ) }</div>
-										<textarea class="minn-input" id="minn-p-note" rows="3" placeholder="${ esc( __( 'Sent to the customer after they buy this…' ) ) }">${ esc( wcPlainText( p.purchase_note ) ) }</textarea>
-									</div>
-									<div><div class="minn-field-label">${ esc( __( 'Menu order' ) ) }</div><input class="minn-input" id="minn-p-menuorder" type="number" step="1" value="${ esc( String( p.menu_order != null ? p.menu_order : 0 ) ) }"></div>
-									${ productToggleHtml( 'minn-p-reviews', __( 'Enable reviews' ), p.reviews_allowed ) }
-								</div>
-							</div>` : '' }
-							${ canEdit ? `
-							<div class="minn-order-panel wide">
-								<div class="minn-side-title" style="margin:0 0 8px;">${ esc( __( 'Attributes' ) ) }</div>
+								</div>` ) : '' }
+							${ canEdit ? card( 'attributes', __( 'Attributes' ), `
 								<div class="minn-pattr-list" id="minn-p-attrs">${ productAttributesHtml( m ) }</div>
 								<div class="minn-pimg-foot">
 									<button type="button" class="minn-btn-soft" id="minn-p-attr-add">${ esc( __( 'Add attribute' ) ) }</button>
@@ -9564,33 +9537,63 @@
 										<div class="minn-ac-panel" hidden></div>
 									</div>` : '' }
 									<span class="minn-toggle-desc">${ esc( __( 'Values are separated by commas. Turn on Variations to vary a variable product by an attribute.' ) ) }</span>
-								</div>
-							</div>` : '' }
-							${ canEdit && ( p.type || 'simple' ) === 'variable' ? `
-							<div class="minn-order-panel wide">
-								<div class="minn-side-title" style="margin:0 0 8px;">${ esc( __( 'Variations' ) ) }</div>
+								</div>` ) : '' }
+							${ canEdit && ( p.type || 'simple' ) === 'variable' ? card( 'variations', __( 'Variations' ), `
 								<div class="minn-pvar-list" id="minn-p-variations">${ productVariationsHtml( m ) }</div>
 								<div class="minn-pimg-foot">
 									<button type="button" class="minn-btn-soft" id="minn-p-var-gen">${ esc( __( 'Generate from attributes' ) ) }</button>
 									<button type="button" class="minn-btn-soft" id="minn-p-var-add">${ esc( __( 'Add variation' ) ) }</button>
 									<span class="minn-toggle-desc">${ esc( __( 'Variations save with the rest of the page.' ) ) }</span>
-								</div>
-							</div>` : '' }
-							${ canEdit ? `
-							<div class="minn-order-panel">
-								<div class="minn-side-title" style="margin:0 0 8px;">${ esc( __( 'Linked products' ) ) }</div>
+								</div>` ) : '' }
+							${ canEdit ? card( 'advanced', __( 'Advanced' ), `
+								<div class="minn-order-fields">
+									<div>
+										<div class="minn-field-label">${ esc( __( 'Purchase note' ) ) }</div>
+										<textarea class="minn-input" id="minn-p-note" rows="3" placeholder="${ esc( __( 'Sent to the customer after they buy this…' ) ) }">${ esc( wcPlainText( p.purchase_note ) ) }</textarea>
+									</div>
+									<div><div class="minn-field-label">${ esc( __( 'Menu order' ) ) }</div><input class="minn-input" id="minn-p-menuorder" type="number" step="1" value="${ esc( String( p.menu_order != null ? p.menu_order : 0 ) ) }"></div>
+									${ productToggleHtml( 'minn-p-reviews', __( 'Enable reviews' ), p.reviews_allowed ) }
+								</div>` ) : '' }`;
+		// The sidebar is editing-only: with no capability the page is a summary,
+		// and an empty 340px column beside it would be a hole in the layout.
+		const side = ! canEdit ? '' : `
+							${ card( 'status', __( 'Status' ), `
+								<div class="minn-order-fields">
+									${ combo( 'minn-p-status' ) }
+									${ combo( 'minn-p-vis' ) }
+									${ productToggleHtml( 'minn-p-featured', __( 'Featured product' ), p.featured ) }
+								</div>` ) }
+							${ card( 'organization', __( 'Organization' ), `
+								<div class="minn-order-fields">
+									${ combo( 'minn-p-type' ) }
+									${ productToggleHtml( 'minn-p-virtual', __( 'Virtual' ), !! p.virtual ) }
+									${ productToggleHtml( 'minn-p-downloadable', __( 'Downloadable' ), !! p.downloadable ) }
+									${ PRODUCT_TERM_FIELDS.map( ( t ) => productTermFieldHtml( m, t ) ).join( '' ) }
+									<div><div class="minn-field-label">${ esc( __( 'Slug' ) ) }</div>
+										<div class="minn-slug-field">
+											<span class="minn-slug-prefix">/</span>
+											<input class="minn-input minn-slug-input" id="minn-p-slug" value="${ esc( p.slug || '' ) }" placeholder="${ esc( __( 'set-on-save' ) ) }" autocomplete="off" spellcheck="false">
+										</div>
+										${ p.status === 'publish' ? `<div class="minn-slug-note">${ esc( __( 'Changing this breaks the current URL.' ) ) }</div>` : '' }
+									</div>
+								</div>` ) }
+							${ card( 'linked', __( 'Linked products' ), `
 								<div class="minn-order-fields">
 									${ PRODUCT_LINK_FIELDS.map( ( f ) => productLinkFieldHtml( m, f ) ).join( '' ) }
-								</div>
-							</div>` : '' }
-							${ canEdit ? `
-							<div class="minn-order-panel wide">
-								<div class="minn-side-title" style="margin:0 0 8px;">${ esc( __( 'Short description' ) ) }</div>
-								<textarea class="minn-input" id="minn-p-short" rows="3" placeholder="${ esc( __( 'Shown near the price in the shop…' ) ) }">${ esc( wcPlainText( p.short_description ) ) }</textarea>
-								<div class="minn-toggle-desc" style="margin-top:6px;">${ esc( __( "Plain text summary. The full description, with blocks and images, opens in Minn's editor." ) ) }</div>
-							</div>` : '' }
+								</div>` ) }`;
+		return `
+					<div class="minn-order-body">
+						<div class="minn-order-layout${ side ? '' : ' minn-order-layout-solo' }">
+							<div class="minn-order-main">${ main }</div>
+							${ side ? `<div class="minn-order-side">${ side }</div>` : '' }
 						</div>
-						${ canEdit ? `
+						${ canEdit && m.page ? `
+						<div class="minn-psavebar" id="minn-p-savebar" hidden>
+							<span class="minn-psavebar-note">${ esc( __( 'Unsaved changes' ) ) }</span>
+							<button class="minn-btn-soft" id="minn-p-discard" type="button">${ esc( __( 'Discard' ) ) }</button>
+							<button class="minn-btn-primary" id="minn-product-save" type="button">${ esc( __( 'Save changes' ) ) }</button>
+						</div>` : '' }
+						${ canEdit && ! m.page ? `
 						<div class="minn-media-edit minn-order-status">
 							<button class="minn-btn-primary" id="minn-product-save" type="button">${ esc( __( 'Save changes' ) ) }</button>
 							<div class="minn-toggle-desc" style="margin-top:8px;">${ esc( __( 'Saves the fields on this page and the short description.' ) ) }</div>
@@ -9723,6 +9726,10 @@
 		const repaint = () => {
 			grid.innerHTML = productImagesGridHtml( m.images );
 			bindTiles();
+			// The media picker is a modal over the page, so the click that
+			// changed this never bubbled through the body the save bar
+			// watches. Tell it directly.
+			if ( m.syncDirty ) m.syncDirty();
 		};
 		const bindTiles = () => {
 			$$( '[data-pimgx]', grid ).forEach( ( b ) => b.addEventListener( 'click', ( e ) => {
@@ -10142,6 +10149,19 @@
 	}
 
 	/**
+	 * What the page would save, as one string. The save bar rides this rather
+	 * than a dirty flag per control: buildProductPayload already reads every
+	 * field on screen, so what it produces IS the answer to "did anything
+	 * change", and it cannot drift from the save the way a second reader would.
+	 * Opening a picker and cancelling leaves it untouched; a chip, a dragged
+	 * image tile or a flipped switch does not, and none of those fire an input
+	 * event. Variations ride along because they save with the page.
+	 */
+	function productFingerprint( m ) {
+		return JSON.stringify( [ buildProductPayload( m, m.full || m.product ), m.variations || [] ] );
+	}
+
+	/**
 	 * Type, Virtual and Downloadable decide which cards exist, so changing one
 	 * has to repaint the page. Everything on screen is read back into the model
 	 * FIRST: a repaint rebuilds the form from m.full, and without this the
@@ -10157,6 +10177,51 @@
 		PRODUCT_LINK_FIELDS.forEach( ( f ) => delete payload[ f.key ] );
 		delete payload.attributes;
 		m.full = Object.assign( {}, m.full, payload );
+	}
+
+	/**
+	 * The page's save bar: hidden until the form stops matching the product as
+	 * it loaded, and hidden again the moment it matches once more, because
+	 * typing an edit and typing it back really is no change.
+	 *
+	 * It watches clicks as well as input, since half of this page is not
+	 * typing: switches, chips, image tiles and combobox picks all move the
+	 * payload without ever firing an input event. The click check is deferred a
+	 * tick so the handler behind it has already mutated the model. Controls
+	 * that live OUTSIDE this body — the media picker, the date picker — call
+	 * m.syncDirty() themselves, because their clicks never reach here.
+	 */
+	function bindProductDirtyBar( m ) {
+		const bar = $( '#minn-p-savebar' );
+		if ( ! bar ) return;
+		// The line is drawn here rather than at load time: every vocabulary the
+		// form needs is fetched BEFORE the first paint (loadProductDetail waits
+		// on all of them), so the first bind sees the product exactly as it
+		// arrived and no late render can move the line under it.
+		if ( m.clean == null ) m.clean = productFingerprint( m );
+		const sync = () => { bar.hidden = productFingerprint( m ) === m.clean; };
+		m.syncDirty = sync;
+		sync();
+		const body = bar.parentElement;
+		if ( body ) {
+			[ 'input', 'change' ].forEach( ( ev ) => body.addEventListener( ev, sync ) );
+			body.addEventListener( 'click', () => setTimeout( sync, 0 ) );
+		}
+		const discard = $( '#minn-p-discard' );
+		if ( discard ) discard.addEventListener( 'click', () => {
+			if ( ! m.loaded ) return;
+			// Rebuild from the untouched copy, not from m.full: a type flip
+			// harvests the form into m.full, so by now it can hold the very
+			// edits being discarded.
+			m.full = JSON.parse( JSON.stringify( m.loaded ) );
+			seedProductTerms( m );
+			seedProductImages( m );
+			seedProductDownloads( m );
+			seedProductVariations( m, m.loadedVariations || [] );
+			seedProductLinks( m, m.linkNames || {} );
+			seedProductAttributes( m );
+			renderProductPage();
+		} );
 	}
 
 	/**
@@ -10215,6 +10280,7 @@
 		// revisions (docs/woocommerce-products.md).
 		const edBtn = $( '#minn-p-editor' );
 		if ( edBtn ) edBtn.addEventListener( 'click', () => go( 'editor/product/' + p.id ) );
+		bindProductDirtyBar( m );
 		bindProductTermFields( m );
 		bindProductLinkFields( m, p );
 		bindProductAttributes( m );
@@ -10225,7 +10291,9 @@
 		// styled); the value it commits lands on the input's dataset.
 		[ '#minn-p-salefrom', '#minn-p-saleto' ].forEach( ( sel ) => {
 			const el = $( sel );
-			if ( el ) bindDatePicker( el, () => {} );
+			// The picker's popover is not inside the body either, so a date
+			// commits without the save bar seeing a thing.
+			if ( el ) bindDatePicker( el, () => { if ( m.syncDirty ) m.syncDirty(); } );
 		} );
 		const saveBtn = $( '#minn-product-save' );
 		if ( saveBtn ) saveBtn.addEventListener( 'click', async () => {
@@ -10255,6 +10323,12 @@
 				}
 				if ( isCur() ) {
 					m.full = full || updated;
+					// The saved product is the new baseline, for the save bar
+					// and for Discard alike; m.clean is rebuilt on the repaint
+					// that follows, from the form this paints.
+					m.loaded = JSON.parse( JSON.stringify( m.full ) );
+					m.loadedVariations = freshVariations;
+					m.clean = null;
 					seedProductTerms( m );
 					seedProductImages( m );
 					seedProductDownloads( m );
@@ -10305,8 +10379,12 @@
 		const p = m.full || m.product;
 		const loading = !! m.loading && ! m.full;
 		const sub = `${ productTypeLabel( p.type ) }${ p.sku ? ' · SKU ' + p.sku : '' }${ p.id ? ' · #' + p.id : '' }`;
+		// Wide, and no card wrapper around the body: the sections are cards
+		// themselves now, and an overflow:hidden wrapper would also become the
+		// containing block for the sticky save bar, which would then stick to
+		// nothing. Same shell as renderOrderPage.
 		view.innerHTML = `
-		<div class="minn-order-page">
+		<div class="minn-order-page minn-order-page-wide">
 			<div class="minn-order-page-head">
 				<button type="button" class="minn-btn-soft" id="minn-pp-back">← ${ esc( __( 'Products' ) ) }</button>
 				<div class="minn-modal-title-block">
@@ -10315,8 +10393,8 @@
 				</div>
 				${ p.status ? `<span class="minn-status ${ PRODUCT_STATUS_STYLE[ p.status ] || 'draft' }">${ esc( statusLabel( p.status ) ) }</span>` : '' }
 			</div>
-			<div class="minn-order-page-card">
-				${ loading ? `<div class="minn-loading" style="padding:28px;">${ esc( __( 'Loading product…' ) ) }</div>` : '' }
+			<div class="minn-order-page-body">
+				${ loading ? `<div class="minn-order-sec"><div class="minn-loading" style="padding:28px;">${ esc( __( 'Loading product…' ) ) }</div></div>` : '' }
 				${ m.loadError ? `<div class="minn-empty" style="padding:20px;">${ esc( m.loadError ) }</div>` : '' }
 				${ ! loading && ! m.loadError ? productDetailInnerHtml( m ) : '' }
 			</div>

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -33357,6 +33357,18 @@
 							: sprintf( esc( /* translators: %s: a "browse" link. */ __( 'Drag & drop an image here, or %s' ) ), `<b>${ esc( __( 'browse' ) ) }</b>` ) + ' ' + esc( __( '(it’s used right away)' ) ) }</span>
 						<input type="file" id="minn-picker-file" accept="image/*"${ m.multi ? ' multiple' : '' } hidden>
 					</div>` : '' }
+					${ m.upload ? `
+					<div class="minn-upl" id="minn-picker-upl">
+						<div class="minn-upl-row">
+							<span class="minn-cell-clip" id="minn-picker-upl-name">${ esc( m.upload.name ) }</span>
+							<span class="minn-upl-pct" id="minn-picker-upl-pct">${ esc( percentLabel( m.upload.pct ) ) }</span>
+						</div>
+						<div class="minn-upl-bar"><span id="minn-picker-upl-fill" style="width:${ Math.max( 2, m.upload.pct || 0 ) }%"></span></div>
+						${ m.upload.total > 1 ? `<div class="minn-upl-count">${ sprintf(
+			/* translators: 1: the file being uploaded, 2: how many files in all. */
+			esc( __( 'File %1$s of %2$s' ) ), esc( formattedNumber( m.upload.index ) ), esc( formattedNumber( m.upload.total ) )
+		) }</div>` : '' }
+					</div>` : '' }
 					${ items == null ? `<div class="minn-loading">${ esc( any ? __( 'Loading files…' ) : __( 'Loading images…' ) ) }</div>` : ! items.length ? `<div class="minn-empty">${ esc( any ? __( 'No files in the library yet.' ) : __( 'No images in the library yet.' ) ) }</div>` : `
 					<div class="minn-picker-grid${ any ? ' any' : '' }">
 						${ items.map( ( it, i ) => it.thumb
@@ -34103,10 +34115,23 @@
 			const drop = $( '#minn-picker-drop' );
 			if ( drop ) {
 				const fileInput = $( '#minn-picker-file' );
-				const uploadOne = async ( file ) => {
-					const fd = new FormData();
-					fd.append( 'file', file );
-					const up = await api( 'wp/v2/media', { method: 'POST', body: fd } );
+				// Progress patches the readout in place. A re-render per
+				// percent would rebuild the whole modal (and lose the grid's
+				// scroll) sixty times a file; renderOverlays runs only when
+				// the readout is not on screen yet.
+				const showProgress = ( name, index, total, pct ) => {
+					m.upload = { name, index, total, pct };
+					const fill = $( '#minn-picker-upl-fill' );
+					const pctEl = $( '#minn-picker-upl-pct' );
+					const nameEl = $( '#minn-picker-upl-name' );
+					if ( ! fill || ! pctEl || ! nameEl ) { renderOverlays(); return; }
+					fill.style.width = Math.max( 2, pct ) + '%';
+					pctEl.textContent = percentLabel( pct );
+					nameEl.textContent = name;
+				};
+				const uploadOne = async ( file, index, total ) => {
+					showProgress( file.name, index, total, 0 );
+					const up = await uploadMedia( file, ( pct ) => showProgress( file.name, index, total, pct ) );
 					state.cache.media = null; // library changed
 					const sizes = up.media_details && up.media_details.sizes;
 					return {
@@ -34133,7 +34158,7 @@
 					toast( __( 'Uploading…' ) );
 					try {
 						if ( ! m.multi ) {
-							const it = await uploadOne( list[ 0 ] );
+							const it = await uploadOne( list[ 0 ], 1, 1 );
 							const cb = m.callback;
 							closeModal();
 							if ( cb ) cb( it );
@@ -34142,12 +34167,16 @@
 						}
 						let done = 0;
 						for ( const file of list ) {
-							const it = await uploadOne( file );
+							const it = await uploadOne( file, done + 1, list.length );
 							// Newest first, and picked, so the gallery grows in
 							// the order the files were handed over.
 							m.items.unshift( it );
 							m.picked.push( it.id );
 							done++;
+							// The readout stays up between files: the batch is
+							// not finished, and a gap would read as one.
+							if ( done < list.length ) m.upload = { name: file.name, index: done + 1, total: list.length, pct: 0 };
+							else m.upload = null;
 							renderOverlays();
 							// The re-render replaced the zone, so the busy mark
 							// goes back on the new one while files remain.
@@ -34159,6 +34188,9 @@
 					} catch ( e ) {
 						toast( e.message, true );
 						drop.classList.remove( 'minn-busy' );
+					} finally {
+						// However it ended, nothing is uploading now.
+						if ( m.upload ) { m.upload = null; renderOverlays(); }
 					}
 				};
 				drop.addEventListener( 'click', () => fileInput.click() );
@@ -36838,6 +36870,62 @@
 				killAll.disabled = false;
 			}
 		} );
+	}
+
+	/**
+	 * Upload one file to the media library, reporting how much of it has gone
+	 * out. This is the one place in the app that uses XMLHttpRequest rather
+	 * than fetch, and the reason is exactly that: fetch cannot report REQUEST
+	 * progress, so a fetch upload can only say "working" and never "62%".
+	 *
+	 * It carries the same nonce api() does, and on a stale one it refreshes and
+	 * retries once, matching apiRes rather than failing a session that is fine.
+	 */
+	function uploadMedia( file, onProgress, retried ) {
+		return new Promise( ( resolve, reject ) => {
+			const fd = new FormData();
+			fd.append( 'file', file );
+			const xhr = new XMLHttpRequest();
+			xhr.open( 'POST', B.restUrl + 'wp/v2/media' );
+			xhr.setRequestHeader( 'X-WP-Nonce', B.nonce );
+			xhr.withCredentials = true;
+			xhr.upload.addEventListener( 'progress', ( e ) => {
+				if ( ! e.lengthComputable || ! onProgress ) return;
+				onProgress( Math.min( 100, Math.round( ( e.loaded / e.total ) * 100 ) ) );
+			} );
+			// The bytes are out but WordPress is still cutting thumbnails, so
+			// the bar rests at 100 while it works instead of stalling at 99.
+			xhr.upload.addEventListener( 'load', () => { if ( onProgress ) onProgress( 100 ); } );
+			xhr.addEventListener( 'load', async () => {
+				let body = null;
+				try { body = JSON.parse( xhr.responseText ); } catch ( e ) { /* not JSON */ }
+				if ( xhr.status >= 200 && xhr.status < 300 ) { resolve( body ); return; }
+				if ( body && body.code === 'rest_cookie_invalid_nonce' && ! retried && B.ajaxUrl ) {
+					try {
+						await refreshRestNonce();
+					} catch ( e ) {
+						sessionExpiredReload();
+						reject( new Error( __( 'Your session expired.' ) ) );
+						return;
+					}
+					uploadMedia( file, onProgress, true ).then( resolve, reject );
+					return;
+				}
+				reject( new Error( body && body.message ? stripTags( body.message ) : xhr.status + ' ' + xhr.statusText ) );
+			} );
+			xhr.addEventListener( 'error', () => reject( new Error( __( 'Upload failed' ) ) ) );
+			xhr.send( fd );
+		} );
+	}
+
+	// A percentage in the user's locale: the sign is not always trailing, and
+	// this is read while a bar fills, so it has to be a number they recognise.
+	function percentLabel( pct ) {
+		try {
+			return new Intl.NumberFormat( uiLocale(), { style: 'percent' } ).format( ( pct || 0 ) / 100 );
+		} catch ( e ) {
+			return ( pct || 0 ) + '%';
+		}
 	}
 
 	function openMediaPicker( callback, opts = {} ) {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -10279,7 +10279,15 @@
 		// /editor/product/{id} is the real writing surface, with blocks and
 		// revisions (docs/woocommerce-products.md).
 		const edBtn = $( '#minn-p-editor' );
-		if ( edBtn ) edBtn.addEventListener( 'click', () => go( 'editor/product/' + p.id ) );
+		if ( edBtn ) edBtn.addEventListener( 'click', () => {
+			// Leave a trail, the way an order does for a subscription: the
+			// editor's own exits are the nav and the browser's Back, so a
+			// description opened from here would otherwise be a one-way door.
+			// Only from the page — the modal keeps its host on screen.
+			const label = p.name || __( 'Product' );
+			if ( m.page ) setPageReturn( 'products/' + p.id, label.length > 32 ? label.slice( 0, 31 ) + '…' : label );
+			go( 'editor/product/' + p.id );
+		} );
 		bindProductDirtyBar( m );
 		bindProductTermFields( m );
 		bindProductLinkFields( m, p );
@@ -24868,6 +24876,15 @@
 
 	function renderEditor() {
 		const view = $( '#minn-view' );
+		// The trail is spent on the first render of the arrival and kept
+		// against the id it was left for, so opening a different post drops it
+		// and a reload (which leaves no trail) offers no back at all. The
+		// editor re-renders constantly, hence keeping it rather than reading
+		// takePageReturn() where the button is drawn.
+		const arrived = takePageReturn();
+		if ( arrived ) state.editorReturn = Object.assign( { id: state.editorId }, arrived );
+		const back = state.editorReturn && String( state.editorReturn.id ) === String( state.editorId )
+			? state.editorReturn : null;
 		if ( ! state.editor || ( state.editorId && state.editor.id !== state.editorId ) || ( ! state.editorId && state.editor.id ) ) {
 			state.editor = null;
 			view.innerHTML = `<div class="minn-loading">${ esc( __( 'Loading editor…' ) ) }</div>`;
@@ -24891,6 +24908,7 @@
 		view.innerHTML = `
 		<div class="minn-editor">
 			<div>
+				${ back ? `<button type="button" class="minn-btn-soft minn-editor-back" id="minn-editor-back">← ${ esc( back.label ) }</button>` : '' }
 				<textarea class="minn-editor-title" id="minn-editor-title" rows="1" placeholder="Untitled ${ esc( editorNoun( ed ).toLowerCase() ) }" aria-label="${ esc( __( 'Title' ) ) }">${ esc( ed.title ) }</textarea>
 				${ ed.type === 'blocks' && ed.id && ed.syncedPattern ? `
 				<div class="minn-editor-locked-note minn-pattern-note">
@@ -24937,6 +24955,8 @@
 			<div class="minn-editor-side" id="minn-editor-side"></div>
 		</div>`;
 
+		const backBtn = $( '#minn-editor-back', view );
+		if ( backBtn ) backBtn.addEventListener( 'click', () => go( back.route ) );
 		const body = $( '#minn-editor-body', view );
 		// Blank posts must not stay truly empty: a contenteditable with no
 		// children puts the first keystrokes in a bare text node, and the

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -8833,6 +8833,24 @@
 	}
 
 	// The attributes a variable product varies by, with their allowed values.
+	/**
+	 * A sale price has to sit BELOW the regular one. WooCommerce does not
+	 * refuse a higher (or equal) one: it answers 200 and drops the sale price
+	 * without a word, on a product and on a variation alike, verified against a
+	 * live store. So without this the reader gets a success toast and no sale.
+	 * Returns the reason it is wrong, or '' when the pair is fine.
+	 */
+	function salePriceProblem( regular, sale ) {
+		const s = String( sale == null ? '' : sale ).trim();
+		if ( ! s ) return '';
+		const sv = parseFloat( s );
+		const rv = parseFloat( String( regular == null ? '' : regular ).trim() );
+		if ( Number.isNaN( sv ) ) return __( 'The sale price is not a number.' );
+		if ( Number.isNaN( rv ) ) return __( 'Set a regular price before a sale price.' );
+		if ( sv >= rv ) return __( 'The sale price has to be lower than the regular price.' );
+		return '';
+	}
+
 	function variationAxes( m ) {
 		return ( m.attributes || [] ).filter( ( a ) => a.variation && a.options.length );
 	}
@@ -8962,6 +8980,7 @@
 						<input class="minn-input" id="minn-var-qty" type="number" step="1" value="${ v.stock_quantity == null ? '' : esc( String( v.stock_quantity ) ) }">
 					</div>
 				</div>
+				<div class="minn-var-error" hidden></div>
 				<div class="minn-toggle-desc minn-var-note">${ esc( __( 'Variations save with the rest of the page.' ) ) }</div>
 				<div class="minn-confirm-actions">
 					<button class="minn-btn-soft" data-var-cancel type="button">${ esc( __( 'Cancel' ) ) }</button>
@@ -9022,10 +9041,33 @@
 			} );
 			imgX.addEventListener( 'click', () => { v.image = null; paintImage(); } );
 
+			const errBox = overlay.querySelector( '.minn-var-error' );
+			const refuse = ( msg, field ) => {
+				errBox.textContent = msg;
+				errBox.hidden = false;
+				const el = overlay.querySelector( field );
+				if ( el ) el.focus();
+			};
 			overlay.querySelector( '[data-var-done]' ).addEventListener( 'click', () => {
-				v.regular_price = ( overlay.querySelector( '#minn-var-regular' ).value || '' ).trim();
-				v.sale_price = ( overlay.querySelector( '#minn-var-sale' ).value || '' ).trim();
-				v.sku = ( overlay.querySelector( '#minn-var-sku' ).value || '' ).trim();
+				const regular = ( overlay.querySelector( '#minn-var-regular' ).value || '' ).trim();
+				const sale = ( overlay.querySelector( '#minn-var-sale' ).value || '' ).trim();
+				const sku = ( overlay.querySelector( '#minn-var-sku' ).value || '' ).trim();
+				const priceProblem = salePriceProblem( regular, sale );
+				if ( priceProblem ) { refuse( priceProblem, '#minn-var-sale' ); return; }
+				// SKUs are unique store-wide, and WooCommerce enforces that at
+				// save time. What can be answered here without a request is the
+				// clash inside this product, which is the common one: the
+				// parent's SKU and the other variants'.
+				if ( sku ) {
+					const parentSku = ( ( $( '#minn-p-sku' ) || {} ).value || '' ).trim();
+					const taken = parentSku.toLowerCase() === sku.toLowerCase()
+						|| m.variations.some( ( x, i ) => i !== index && ( x.sku || '' ).trim().toLowerCase() === sku.toLowerCase() );
+					if ( taken ) { refuse( __( 'That SKU is already used on this product.' ), '#minn-var-sku' ); return; }
+				}
+				errBox.hidden = true;
+				v.regular_price = regular;
+				v.sale_price = sale;
+				v.sku = sku;
 				v.manage_stock = track.classList.contains( 'on' );
 				const raw = ( overlay.querySelector( '#minn-var-qty' ).value || '' ).trim();
 				v.stock_quantity = v.manage_stock ? ( raw === '' ? 0 : parseInt( raw, 10 ) ) : null;
@@ -9146,10 +9188,25 @@
 			else body.create.push( row );
 		} );
 		if ( ! body.create.length && ! body.update.length && ! body.delete.length ) return;
-		await api( `wc/v3/products/${ productId }/variations/batch`, {
+		const res = await api( `wc/v3/products/${ productId }/variations/batch`, {
 			method: 'POST',
 			body: JSON.stringify( body ),
 		} );
+		// A batch answers 200 even when it refused an item: the refusal rides
+		// INSIDE that item. Verified with a duplicate SKU, which comes back as
+		// product_invalid_sku and even names a SKU that is free. Swallowing it
+		// let a save report success while the variation kept its old value.
+		const refused = [ 'create', 'update', 'delete' ]
+			.reduce( ( all, k ) => all.concat( Array.isArray( ( res || {} )[ k ] ) ? res[ k ] : [] ), [] )
+			.filter( ( row ) => row && row.error );
+		if ( refused.length ) {
+			const err = refused[ 0 ].error || {};
+			const free = err.data && err.data.unique_sku;
+			throw new Error( free
+				/* translators: 1: WooCommerce's own error message, 2: a SKU that is not taken. */
+				? sprintf( __( '%1$s Try %2$s.' ), err.message || __( 'A variation was refused.' ), free )
+				: ( err.message || __( 'A variation was refused.' ) ) );
+		}
 		m.variationsRemoved = [];
 	}
 
@@ -10686,6 +10743,18 @@
 			const name = ( ( $( '#minn-p-name' ) || {} ).value || '' ).trim();
 			if ( ! name ) {
 				toast( __( 'Name is required' ), true );
+				return;
+			}
+			// Same trap the variant editor guards: WooCommerce takes a sale
+			// price that is not lower with a 200 and quietly drops it.
+			const priceProblem = salePriceProblem(
+				( $( '#minn-p-regular' ) || {} ).value,
+				( $( '#minn-p-sale' ) || {} ).value
+			);
+			if ( priceProblem ) {
+				toast( priceProblem, true );
+				const saleEl = $( '#minn-p-sale' );
+				if ( saleEl ) saleEl.focus();
 				return;
 			}
 			const payload = buildProductPayload( m, p );

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -9043,9 +9043,9 @@
 	// The Organization card's taxonomies. A store without brands answers with
 	// no `brands` key at all, which is how that field knows to stay away.
 	const PRODUCT_TERM_FIELDS = [
-		{ key: 'categories', label: __( 'Categories' ), route: 'products/categories', create: false, placeholder: __( 'Search categories…' ) },
-		{ key: 'tags', label: __( 'Tags' ), route: 'products/tags', create: true, placeholder: __( 'Add a tag, press Enter' ) },
-		{ key: 'brands', label: __( 'Brands' ), route: 'products/brands', create: true, placeholder: __( 'Add a brand, press Enter' ) },
+		{ key: 'categories', label: __( 'Categories' ), route: 'products/categories', create: false, placeholder: __( 'Search categories' ) },
+		{ key: 'tags', label: __( 'Tags' ), route: 'products/tags', create: true, placeholder: __( 'Search or add tags' ), addLabel: __( 'Add new tag' ) },
+		{ key: 'brands', label: __( 'Brands' ), route: 'products/brands', create: true, placeholder: __( 'Search or add brands' ), addLabel: __( 'Add new brand' ) },
 	];
 
 	// Downloadable files ride the model too. WooCommerce mints the id for a new
@@ -9906,16 +9906,26 @@
 			const repaintChips = () => {
 				chips.innerHTML = productTermChipsHtml( m.links[ f.key ] );
 				bindChips();
+				if ( m.syncDirty ) m.syncDirty();
 			};
 			bindChips();
 			let timer = null;
+			// One generation per request: a slow answer to an earlier keystroke
+			// must not repaint over a newer one or stop its spinner.
+			let seq = 0;
 			input.addEventListener( 'input', () => {
 				clearTimeout( timer );
 				timer = setTimeout( async () => {
 					const q = input.value.trim();
-					if ( ! q ) { panel.hidden = true; return; }
+					if ( ! q ) { panel.hidden = true; wrap.classList.remove( 'is-loading' ); return; }
+					const mine = ++seq;
+					wrap.classList.add( 'is-loading' );
+					panel.innerHTML = `<div class="minn-ac-empty">${ esc( __( 'Searching…' ) ) }</div>`;
+					panel.hidden = false;
 					try {
 						const rows = await api( `wc/v3/products?search=${ encodeURIComponent( q ) }&per_page=20&_fields=id,name,sku` );
+						if ( mine !== seq ) return;
+						wrap.classList.remove( 'is-loading' );
 						const chosen = new Set( ( m.links[ f.key ] || [] ).map( ( x ) => x.id ) );
 						const items = ( Array.isArray( rows ) ? rows : [] )
 							.filter( ( r ) => r.id !== p.id && ! chosen.has( r.id ) );
@@ -9934,7 +9944,14 @@
 							panel.hidden = true;
 							repaintChips();
 						} ) );
-					} catch ( e ) { /* search hiccup — keep typing */ }
+					} catch ( e ) {
+						// Search hiccup: keep typing, but never leave the field
+						// spinning at a request that is not coming back.
+						if ( mine === seq ) {
+							wrap.classList.remove( 'is-loading' );
+							panel.hidden = true;
+						}
+					}
 				}, 250 );
 			} );
 			input.addEventListener( 'keydown', ( e ) => {
@@ -9965,10 +9982,36 @@
 	}
 
 	/**
-	 * Chips plus an async suggest per taxonomy. Tags and brands are flat, so
-	 * Enter creates one that does not exist yet; categories are pick-only,
-	 * because a typo there would leave junk in a hierarchy Minn is not
-	 * editing here (the Terms manager and WooCommerce own that).
+	 * The list a taxonomy field drops: every row a tick box, ticked when the
+	 * product is in that term. Rows come from the server (a store can have
+	 * hundreds of categories, so the filtering is not local), and the first
+	 * page is cached per taxonomy, which is what makes reopening the field
+	 * instant while a search still asks.
+	 */
+	function productTermRowsHtml( m, t, rows ) {
+		const chosen = new Set( ( ( m.terms || {} )[ t.key ] || [] ).map( ( x ) => x.id ) );
+		const body = rows == null
+			? `<div class="minn-ac-empty">${ esc( __( 'Searching…' ) ) }</div>`
+			: ( rows.length
+				? rows.map( ( x ) => `<button type="button" class="minn-ac-item minn-ac-check" role="option" aria-selected="${ chosen.has( x.id ) ? 'true' : 'false' }" data-ptpick="${ x.id }" data-ptname="${ esc( x.name ) }"><span class="minn-check" aria-hidden="true"></span><span class="minn-cell-clip">${ esc( x.name ) }</span></button>` ).join( '' )
+				: `<div class="minn-ac-empty">${ t.create ? esc( __( 'No matches. Press Enter to create it.' ) ) : esc( __( 'No matches' ) ) }</div>` );
+		// Creating from the list is for flat taxonomies only. A category is a
+		// place in a hierarchy, and a typo would leave junk in a tree this
+		// field is not editing (the Terms manager and WooCommerce own that).
+		const foot = t.create
+			? `<div class="minn-ac-foot"><button type="button" class="minn-ac-item minn-ac-add" data-ptadd>${ icon( 'plus' ) }<span>${ esc( t.addLabel || __( 'Add new' ) ) }</span></button></div>`
+			: '';
+		return body + foot;
+	}
+
+	/**
+	 * Chips plus a list per taxonomy, in the shape Shopify's collections field
+	 * has: clicking the field shows what exists rather than asking the reader
+	 * to guess a search term, and a row toggles without closing, so putting a
+	 * product in four categories is four clicks and not four searches.
+	 *
+	 * Tags and brands are flat, so Enter (or Add new) creates one that does not
+	 * exist yet; categories are pick-only.
 	 */
 	function bindProductTermFields( m ) {
 		PRODUCT_TERM_FIELDS.forEach( ( t ) => {
@@ -9977,53 +10020,35 @@
 			if ( ! wrap || ! chips || ! Array.isArray( ( m.terms || {} )[ t.key ] ) ) return;
 			const input = wrap.querySelector( '.minn-ac-input' );
 			const panel = wrap.querySelector( '.minn-ac-panel' );
+			const cache = ( state.cache.productTerms = state.cache.productTerms || {} );
+			let rows = null;
+			// Every request carries a generation. A slow answer to an earlier
+			// keystroke must not repaint the panel over a newer one, nor call
+			// off the spinner the newer one turned on.
+			let seq = 0;
 			const bindChips = () => $$( '[data-ptchip]', chips ).forEach( ( ch ) =>
 				ch.addEventListener( 'click', () => {
 					const id = parseInt( ch.dataset.ptchip, 10 );
 					m.terms[ t.key ] = m.terms[ t.key ].filter( ( x ) => x.id !== id );
 					repaintChips();
+					if ( ! panel.hidden ) renderPanel();
 				} )
 			);
 			const repaintChips = () => {
 				chips.innerHTML = productTermChipsHtml( m.terms[ t.key ] );
 				bindChips();
+				if ( m.syncDirty ) m.syncDirty();
 			};
-			const add = ( item ) => {
-				if ( ! m.terms[ t.key ].some( ( x ) => x.id === item.id ) ) m.terms[ t.key ].push( item );
-				input.value = '';
-				panel.hidden = true;
+			const toggle = ( item ) => {
+				const at = m.terms[ t.key ].findIndex( ( x ) => x.id === item.id );
+				if ( at === -1 ) m.terms[ t.key ].push( item );
+				else m.terms[ t.key ].splice( at, 1 );
 				repaintChips();
+				renderPanel(); // the tick has to move, and the list stays open
 			};
-			bindChips();
-			let timer = null;
-			input.addEventListener( 'input', () => {
-				clearTimeout( timer );
-				timer = setTimeout( async () => {
-					const q = input.value.trim();
-					if ( ! q ) { panel.hidden = true; return; }
-					try {
-						const items = await api( `wc/v3/${ t.route }?search=${ encodeURIComponent( q ) }&per_page=20&_fields=id,name` );
-						const chosen = new Set( m.terms[ t.key ].map( ( x ) => x.id ) );
-						const rows = ( Array.isArray( items ) ? items : [] )
-							.map( ( x ) => ( { id: x.id, name: decodeEntities( x.name || '' ) } ) )
-							.filter( ( x ) => ! chosen.has( x.id ) );
-						panel.innerHTML = rows.length
-							? rows.map( ( x ) => `<button type="button" class="minn-ac-item" data-ptpick="${ x.id }" data-ptname="${ esc( x.name ) }">${ esc( x.name ) }</button>` ).join( '' )
-							: `<div class="minn-ac-empty">${ t.create ? esc( __( 'No matches. Press Enter to create it.' ) ) : esc( __( 'No matches' ) ) }</div>`;
-						panel.hidden = false;
-						$$( '[data-ptpick]', panel ).forEach( ( b ) => b.addEventListener( 'mousedown', ( e ) => {
-							e.preventDefault(); // a plain click blurs the field first
-							add( { id: parseInt( b.dataset.ptpick, 10 ), name: b.dataset.ptname } );
-						} ) );
-					} catch ( e ) { /* search hiccup — keep typing */ }
-				}, 250 );
-			} );
-			input.addEventListener( 'keydown', async ( e ) => {
-				if ( e.key !== 'Enter' ) return;
-				e.preventDefault(); // Enter here must never submit anything
-				if ( ! t.create ) return;
+			const create = async () => {
 				const name = input.value.trim();
-				if ( ! name ) return;
+				if ( ! name ) { input.focus( { preventScroll: true } ); return; }
 				input.disabled = true;
 				try {
 					// Reuse an existing term before making a duplicate.
@@ -10034,13 +10059,66 @@
 					if ( ! match ) {
 						const created = await api( `wc/v3/${ t.route }`, { method: 'POST', body: JSON.stringify( { name } ) } );
 						match = { id: created.id, name: decodeEntities( created.name || name ) };
+						// The cached first page is what the field reopens into,
+						// so a term made here belongs in it.
+						if ( Array.isArray( cache[ t.key ] ) ) cache[ t.key ].unshift( match );
 					}
-					add( match );
+					if ( ! m.terms[ t.key ].some( ( x ) => x.id === match.id ) ) m.terms[ t.key ].push( match );
+					input.value = '';
+					rows = null;
+					panel.hidden = true;
+					repaintChips();
 				} catch ( err ) {
 					toast( err.message, true );
 				}
 				input.disabled = false;
 				input.focus( { preventScroll: true } );
+			};
+			const renderPanel = () => {
+				panel.innerHTML = productTermRowsHtml( m, t, rows );
+				panel.hidden = false;
+				$$( '[data-ptpick]', panel ).forEach( ( b ) => b.addEventListener( 'mousedown', ( e ) => {
+					e.preventDefault(); // a plain click blurs the field first
+					toggle( { id: parseInt( b.dataset.ptpick, 10 ), name: b.dataset.ptname } );
+				} ) );
+				const addBtn = $( '[data-ptadd]', panel );
+				if ( addBtn ) addBtn.addEventListener( 'mousedown', ( e ) => { e.preventDefault(); create(); } );
+			};
+			const load = async ( q ) => {
+				const mine = ++seq;
+				if ( ! q && Array.isArray( cache[ t.key ] ) ) {
+					rows = cache[ t.key ];
+					renderPanel();
+					return;
+				}
+				rows = null;
+				wrap.classList.add( 'is-loading' );
+				renderPanel(); // Searching…, so the panel is never a blank box
+				try {
+					const items = await api( `wc/v3/${ t.route }?${ q ? 'search=' + encodeURIComponent( q ) + '&' : '' }per_page=20&_fields=id,name` );
+					if ( mine !== seq ) return;
+					rows = ( Array.isArray( items ) ? items : [] )
+						.map( ( x ) => ( { id: x.id, name: decodeEntities( x.name || '' ) } ) );
+					if ( ! q ) cache[ t.key ] = rows;
+				} catch ( e ) {
+					if ( mine !== seq ) return;
+					rows = [];
+				}
+				wrap.classList.remove( 'is-loading' );
+				renderPanel();
+			};
+			bindChips();
+			let timer = null;
+			input.addEventListener( 'focus', () => load( input.value.trim() ) );
+			input.addEventListener( 'input', () => {
+				clearTimeout( timer );
+				timer = setTimeout( () => load( input.value.trim() ), 250 );
+			} );
+			input.addEventListener( 'keydown', ( e ) => {
+				if ( e.key === 'Escape' ) { panel.hidden = true; return; }
+				if ( e.key !== 'Enter' ) return;
+				e.preventDefault(); // Enter here must never submit anything
+				if ( t.create ) create();
 			} );
 			input.addEventListener( 'blur', () => setTimeout( () => { panel.hidden = true; }, 150 ) );
 		} );

--- a/docs/woocommerce-products.md
+++ b/docs/woocommerce-products.md
@@ -181,9 +181,23 @@ its own.
    re-read afterwards so a second save updates them rather than creating
    duplicates.
 
-   Per-variation images and the variation-level shipping and tax fields are not
-   here yet; the card covers what a shop owner changes rather than everything
-   the resource holds.
+   The card later became a LIST of variants rather than a grid of inputs: six
+   variants of five fields each was thirty boxes and no answer to the question
+   the card exists for, which is what this product sells and for how much. A
+   row carries the picture, the variant, the price and what is available, and
+   opens the variant's own editor: attribute values, prices, SKU, stock status,
+   tracking with its quantity, and a picture.
+
+   The editor works on a COPY. A half-typed value left on the live model would
+   ride the next save of anything else on the page, so Cancel has to be a real
+   cancel; Done writes it back and the batch still goes with the page's single
+   Save. Two findings sit under it. WooCommerce clears a variation's picture on
+   `{ id: 0 }` (and on `null`) and sets one on `{ id }`, both verified against
+   a live store. And the media picker has to outrank a dialog it was opened
+   FROM, or it renders behind whatever asked for it.
+
+   Variation-level shipping and tax fields are still not here; the card covers
+   what a shop owner changes rather than everything the resource holds.
 
 Waves 2 through 5 cover what a shop owner touches weekly. Waves 8 and 9 are
 where WooCommerce's own UI is a canvas, so they need their own scoping pass
@@ -198,8 +212,14 @@ product is in that term, and a row toggles without closing, so filing a
 product in four categories is four clicks. Typing still searches the server: a
 store can have hundreds of terms, and filtering the first page locally would
 lie about what exists. The first page is cached per taxonomy so reopening is
-instant. Add new is offered for the flat taxonomies only, for the same reason
-Enter never created a category.
+instant.
+
+Add new opens a dialog, and that dialog is what makes the door reasonable for
+a hierarchy too. The objection was never creating a category, it was creating
+one by ACCIDENT: Enter-to-create still refuses a hierarchy, because a stray
+branch from a typo is not something this field cleans up. A dialog is
+deliberate, and it can ask the one question a hierarchy needs, which is the
+parent.
 
 Every search says that it is searching, in the slot the chevron occupies so
 nothing shifts when the answer lands. Requests carry a generation: a slow

--- a/docs/woocommerce-products.md
+++ b/docs/woocommerce-products.md
@@ -8,6 +8,41 @@ The reference for the page shape is the order page (`renderOrderPage`): one
 shared body renderer feeding both a quick-view modal and a full page, with
 `m.page` telling them apart.
 
+## The shape of the page
+
+Cards on a main column plus a 340px sidebar, the same grid the order page
+uses, and for the same reason: this page runs to ten sections and a two-column
+slab of bordered panels reads as one wall.
+
+The split is Shopify's. The main column is what the product **is**: name and
+summary, pictures, price, stock, size, attributes, variations. The sidebar is
+what it is **filed under**: published or not, type, taxonomies, linked
+products. The grid lives in the page's own stylesheet (`.minn-order-page
+.minn-order-layout`), so the quick-view modal takes the identical markup and
+stacks it. One body, two hosts, as on an order.
+
+Each card carries a `data-pcard` name so the layout can be tested by where a
+card is actually **drawn**, not by where it sits in the markup. A page can
+carry every right class name and still paint as one slab if the CSS never
+lands.
+
+**The save bar** appears when something changes and offers Discard beside
+Save. It rides a fingerprint of `buildProductPayload()` rather than a dirty
+flag per control: that function already reads every field on screen, so what
+it produces IS the answer to "did anything change", and it cannot drift from
+what the save sends. Cancelling out of a picker leaves it down; a chip, a
+dragged tile or a flipped switch raises it, and none of those fire an input
+event, which is why the watcher also listens for clicks (deferred a tick, so
+the model has already moved). Controls whose clicks never reach the body, the
+media picker and the date picker, call `m.syncDirty()` themselves.
+
+Discard rebuilds from a copy of the product taken at load. `m.full` is not
+that copy: flipping the type harvests the form into it, on purpose.
+
+The page therefore has no card wrapper around the body. An `overflow: hidden`
+wrapper would become the sticky bar's containing block, and the bar would
+stick to nothing.
+
 ## The wp-admin metabox, mapped
 
 wp-admin puts all of this behind the Product data metabox's vertical tabs plus a
@@ -153,3 +188,37 @@ its own.
 Waves 2 through 5 cover what a shop owner touches weekly. Waves 8 and 9 are
 where WooCommerce's own UI is a canvas, so they need their own scoping pass
 before anyone starts.
+
+## Two things the fields learned later
+
+**The taxonomy fields open into a list.** Categories, tags and brands were
+search-only, an empty box that answered nothing until you guessed a term that
+exists. They now drop a list on focus with a tick box per row, ticked when the
+product is in that term, and a row toggles without closing, so filing a
+product in four categories is four clicks. Typing still searches the server: a
+store can have hundreds of terms, and filtering the first page locally would
+lie about what exists. The first page is cached per taxonomy so reopening is
+instant. Add new is offered for the flat taxonomies only, for the same reason
+Enter never created a category.
+
+Every search says that it is searching, in the slot the chevron occupies so
+nothing shifts when the answer lands. Requests carry a generation: a slow
+answer to an earlier keystroke must neither repaint over a newer one nor stop
+its spinner. The store-wide attribute picker has no spinner because it never
+waits, its vocabulary is fetched before the first paint.
+
+**The gallery takes several files at once**, and shows each one's name,
+percentage and place in the batch while it uploads. That readout is the reason
+`uploadMedia()` uses XMLHttpRequest: fetch cannot report request progress, so
+a fetch upload can only say "working". Uploads run one after another, not in
+parallel, because a dozen at once is how a shared host answers 503 and because
+the order of the picks is the gallery's order.
+
+**Video does not belong in the gallery, and this is WooCommerce's rule.**
+`set_product_images()` rejects any attachment that is not an image with a 400
+`woocommerce_product_invalid_image_id`, verified against a live store by
+PUTting a `video/mp4` attachment id: the write fails outright, so a picker
+that offered video would offer a save that cannot succeed. A product video
+lives in the long description (Minn's editor takes a video block), in the
+Downloads card for a downloadable product, or in whatever meta field a theme
+reads, which is per-theme and not core.

--- a/tests/product-advanced.test.js
+++ b/tests/product-advanced.test.js
@@ -53,7 +53,7 @@ const { BASE, launch, login, reporter, pickCombo, setSwitch } = require( './help
 		await page.waitForSelector( '#minn-p-note', { timeout: 20000 } );
 
 		const present = await page.evaluate( () => ( {
-			titles: Array.from( document.querySelectorAll( '.minn-order-panel .minn-side-title' ) ).map( ( e ) => e.textContent.trim() ),
+			titles: Array.from( document.querySelectorAll( '.minn-order-sec .minn-side-title' ) ).map( ( e ) => e.textContent.trim() ),
 			from: !! document.querySelector( '#minn-p-salefrom' ),
 			to: !! document.querySelector( '#minn-p-saleto' ),
 			taxStatus: !! document.querySelector( '#minn-p-taxstatus' ),
@@ -142,11 +142,13 @@ const { BASE, launch, login, reporter, pickCombo, setSwitch } = require( './help
 			!! repop.from && /Care instructions/.test( repop.note ) && repop.order === '7'
 			&& repop.reviews === false && repop.tax === 'shipping', JSON.stringify( repop ) );
 
-		await page.evaluate( () => {
-			const el = document.querySelector( '#minn-p-salefrom' );
-			el.dataset.dp = '';
-			el.value = '';
-		} );
+		// Cleared through the picker's own Clear, the way a reader does it.
+		// Writing the dataset by hand would fire no event, and the page's save
+		// bar only comes up when something it can observe actually changes.
+		await page.click( '#minn-p-salefrom' );
+		await page.waitForSelector( '.minn-dp-pop [data-dp-clear]', { timeout: 10000 } );
+		await page.click( '.minn-dp-pop [data-dp-clear]' );
+		await page.waitForTimeout( 200 );
 		await page.click( '#minn-product-save' );
 		await page.waitForFunction( () => {
 			const btn = document.querySelector( '#minn-product-save' );

--- a/tests/product-attributes.test.js
+++ b/tests/product-attributes.test.js
@@ -59,7 +59,7 @@ const { BASE, launch, login, reporter } = require( './helpers' );
 		await page.waitForSelector( '#minn-p-attrs', { timeout: 20000 } );
 
 		const card = await page.evaluate( () => ( {
-			titles: Array.from( document.querySelectorAll( '.minn-order-panel .minn-side-title' ) ).map( ( e ) => e.textContent.trim() ),
+			titles: Array.from( document.querySelectorAll( '.minn-order-sec .minn-side-title' ) ).map( ( e ) => e.textContent.trim() ),
 			empty: /No attributes yet/.test( ( document.querySelector( '#minn-p-attrs' ) || {} ).textContent || '' ),
 			add: !! document.querySelector( '#minn-p-attr-add' ),
 			pick: !! document.querySelector( '[data-pattrglobal]' ),

--- a/tests/product-fields.test.js
+++ b/tests/product-fields.test.js
@@ -69,7 +69,7 @@ const { BASE, launch, login, reporter, pickCombo, comboValue, setSwitch, switchO
 
 		// The groups WooCommerce splits across metabox tabs, on one page.
 		const cards = await page.evaluate( () => Array.from(
-			document.querySelectorAll( '.minn-order-panel .minn-side-title' )
+			document.querySelectorAll( '.minn-order-sec .minn-side-title' )
 		).map( ( el ) => el.textContent.trim() ) );
 		t.check( 'page shows Basics, Pricing, Inventory and Shipping',
 			[ 'Basics', 'Pricing', 'Inventory', 'Shipping' ].every( ( c ) => cards.includes( c ) ),
@@ -181,7 +181,7 @@ const { BASE, launch, login, reporter, pickCombo, comboValue, setSwitch, switchO
 			await page.goto( BASE + '/minn-admin/products/' + virtualId, { waitUntil: 'domcontentloaded' } );
 			await page.waitForSelector( '#minn-p-gtin', { timeout: 20000 } );
 			const vCards = await page.evaluate( () => ( {
-				titles: Array.from( document.querySelectorAll( '.minn-order-panel .minn-side-title' ) ).map( ( el ) => el.textContent.trim() ),
+				titles: Array.from( document.querySelectorAll( '.minn-order-sec .minn-side-title' ) ).map( ( el ) => el.textContent.trim() ),
 				weight: !! document.querySelector( '#minn-p-weight' ),
 				gtin: !! document.querySelector( '#minn-p-gtin' ),
 			} ) );

--- a/tests/product-images.test.js
+++ b/tests/product-images.test.js
@@ -188,6 +188,14 @@ const { BASE, launch, login, reporter } = require( './helpers' );
 			return f ? f.multiple : null;
 		} );
 		t.check( 'the picker browse input takes more than one file', takesMany === true, String( takesMany ) );
+		// A slow answer on purpose: an upload to a local server is over before
+		// a human could see it, and what is being checked is that the wait is
+		// legible while it lasts.
+		await page.route( '**/wp/v2/media**', async ( route ) => {
+			if ( route.request().method() !== 'POST' ) { await route.continue(); return; }
+			await new Promise( ( r ) => setTimeout( r, 1500 ) );
+			await route.continue();
+		} );
 		await page.evaluate( async ( name ) => {
 			const mk = async ( n, colour ) => {
 				const c = document.createElement( 'canvas' );
@@ -206,9 +214,24 @@ const { BASE, launch, login, reporter } = require( './helpers' );
 			Object.defineProperty( ev, 'dataTransfer', { value: dt } );
 			document.querySelector( '#minn-picker-drop' ).dispatchEvent( ev );
 		}, 'minnmulti-' + suffix );
+		await page.waitForSelector( '#minn-picker-upl', { timeout: 20000 } );
+		const progress = await page.evaluate( () => {
+			const el = document.querySelector( '#minn-picker-upl' );
+			return {
+				text: el ? el.textContent.replace( /\s+/g, ' ' ).trim() : '',
+				bar: !! document.querySelector( '#minn-picker-upl-fill' ),
+			};
+		} );
+		t.check( 'the picker names the file it is uploading, with a percentage',
+			/minnmulti/.test( progress.text ) && /%/.test( progress.text ) && progress.bar,
+			JSON.stringify( progress ) );
+		t.check( 'and counts the file against the batch', /\b2\b/.test( progress.text ), progress.text );
 		await page.waitForFunction(
 			() => document.querySelectorAll( '.minn-picker-item.sel' ).length >= 2,
 			null, { timeout: 40000 } ).catch( () => null );
+		await page.unroute( '**/wp/v2/media**' );
+		t.check( 'the readout goes away when the batch is done',
+			! ( await page.$( '#minn-picker-upl' ) ), '' );
 		const selCount = await page.evaluate( () => document.querySelectorAll( '.minn-picker-item.sel' ).length );
 		t.check( 'both dropped files upload and come back selected', selCount === 2, String( selCount ) );
 		await page.click( '#minn-picker-done' );

--- a/tests/product-images.test.js
+++ b/tests/product-images.test.js
@@ -175,6 +175,56 @@ const { BASE, launch, login, reporter } = require( './helpers' );
 			return row ? row.src : '';
 		}, id );
 		t.check( 'the list row shows a thumbnail', /\.(png|jpe?g|webp)/i.test( rowImg ), rowImg );
+
+		// Several files from the machine in one go. The browse input has to
+		// accept a multiple selection, and the drop zone has to upload every
+		// file it is handed rather than the first one.
+		await page.goto( BASE + '/minn-admin/products/' + id, { waitUntil: 'domcontentloaded' } );
+		await page.waitForSelector( '#minn-p-img-add', { timeout: 20000 } );
+		await page.click( '#minn-p-img-add' );
+		await page.waitForSelector( '#minn-picker-drop', { timeout: 15000 } );
+		const takesMany = await page.evaluate( () => {
+			const f = document.querySelector( '#minn-picker-file' );
+			return f ? f.multiple : null;
+		} );
+		t.check( 'the picker browse input takes more than one file', takesMany === true, String( takesMany ) );
+		await page.evaluate( async ( name ) => {
+			const mk = async ( n, colour ) => {
+				const c = document.createElement( 'canvas' );
+				c.width = 50; c.height = 50;
+				const ctx = c.getContext( '2d' );
+				ctx.fillStyle = colour; ctx.fillRect( 0, 0, 50, 50 );
+				const blob = await new Promise( ( r ) => c.toBlob( r, 'image/png' ) );
+				return new File( [ blob ], n + '.png', { type: 'image/png' } );
+			};
+			const dt = new DataTransfer();
+			dt.items.add( await mk( name + '-1', '#8e44ad' ) );
+			dt.items.add( await mk( name + '-2', '#f39c12' ) );
+			// Chrome's DragEvent constructor ignores dataTransfer — pin it on
+			// the instance or the handler sees no files (media-flow, same trap).
+			const ev = new DragEvent( 'drop', { bubbles: true, cancelable: true } );
+			Object.defineProperty( ev, 'dataTransfer', { value: dt } );
+			document.querySelector( '#minn-picker-drop' ).dispatchEvent( ev );
+		}, 'minnmulti-' + suffix );
+		await page.waitForFunction(
+			() => document.querySelectorAll( '.minn-picker-item.sel' ).length >= 2,
+			null, { timeout: 40000 } ).catch( () => null );
+		const selCount = await page.evaluate( () => document.querySelectorAll( '.minn-picker-item.sel' ).length );
+		t.check( 'both dropped files upload and come back selected', selCount === 2, String( selCount ) );
+		await page.click( '#minn-picker-done' );
+		await page.waitForTimeout( 400 );
+		const tilesNow = await page.evaluate( () => document.querySelectorAll( '#minn-p-images [data-pimg]' ).length );
+		t.check( 'both uploads join the gallery', tilesNow === 4, String( tilesNow ) );
+		await page.click( '#minn-product-save' );
+		await page.waitForFunction( () => {
+			const b = document.querySelector( '#minn-product-save' );
+			return b && ! b.disabled && /Save/.test( b.textContent );
+		}, null, { timeout: 20000 } ).catch( () => null );
+		await page.waitForTimeout( 600 );
+		const grown = await api( `wc/v3/products/${ id }?_fields=id,images` );
+		const grownIds = ( ( grown.body || {} ).images || [] ).map( ( x ) => x.id );
+		grownIds.filter( ( x ) => ! media.includes( x ) ).forEach( ( x ) => media.push( x ) );
+		t.check( 'the pair saves into the gallery', grownIds.length === 4, JSON.stringify( grownIds ) );
 	} finally {
 		if ( id ) await api( `wc/v3/products/${ id }?force=true`, { method: 'DELETE' } ).catch( () => null );
 		for ( const mid of media ) {

--- a/tests/product-images.test.js
+++ b/tests/product-images.test.js
@@ -81,7 +81,7 @@ const { BASE, launch, login, reporter } = require( './helpers' );
 		await page.waitForSelector( '#minn-p-images', { timeout: 20000 } );
 
 		const card = await page.evaluate( () => ( {
-			titles: Array.from( document.querySelectorAll( '.minn-order-panel .minn-side-title' ) ).map( ( e ) => e.textContent.trim() ),
+			titles: Array.from( document.querySelectorAll( '.minn-order-sec .minn-side-title' ) ).map( ( e ) => e.textContent.trim() ),
 			tiles: document.querySelectorAll( '#minn-p-images [data-pimg]' ).length,
 			badge: ( ( document.querySelector( '#minn-p-images .minn-imgedit-new' ) || {} ).textContent || '' ).trim(),
 			firstBadged: !! document.querySelector( '#minn-p-images [data-pimg="0"] .minn-imgedit-new' ),

--- a/tests/product-linked.test.js
+++ b/tests/product-linked.test.js
@@ -62,6 +62,24 @@ const { BASE, launch, login, reporter } = require( './helpers' );
 		t.check( 'Linked products card is on the page', card.titles.includes( 'Linked products' ), JSON.stringify( card.titles ) );
 		t.check( 'card carries upsells and cross-sells', card.up && card.cross, JSON.stringify( card ) );
 
+		// The search says it is searching. Delayed on purpose: a local request
+		// answers too fast to catch the state otherwise.
+		await page.route( '**/wc/v3/products?search=**', async ( route ) => {
+			await new Promise( ( r ) => setTimeout( r, 1200 ) );
+			await route.continue();
+		} );
+		await page.fill( '[data-plac="upsell_ids"] .minn-ac-input', 'Linkfi' );
+		await page.waitForTimeout( 500 );
+		const searching = await page.evaluate( () => {
+			const w = document.querySelector( '[data-plac="upsell_ids"]' );
+			return { loading: !! w && w.classList.contains( 'is-loading' ) };
+		} );
+		t.check( 'the upsell search shows it is working', searching.loading, JSON.stringify( searching ) );
+		await page.waitForSelector( '[data-plac="upsell_ids"] [data-plpick]', { timeout: 20000 } );
+		t.check( 'and stops once the matches land',
+			! ( await page.evaluate( () => document.querySelector( '[data-plac="upsell_ids"]' ).classList.contains( 'is-loading' ) ) ), '' );
+		await page.unroute( '**/wc/v3/products?search=**' );
+
 		// Search finds other products and excludes this one.
 		await page.fill( '[data-plac="upsell_ids"] .minn-ac-input', 'Linkfix ' );
 		await page.waitForSelector( '[data-plac="upsell_ids"] [data-plpick]', { timeout: 15000 } );

--- a/tests/product-linked.test.js
+++ b/tests/product-linked.test.js
@@ -55,7 +55,7 @@ const { BASE, launch, login, reporter } = require( './helpers' );
 		await page.waitForSelector( '[data-plac="upsell_ids"]', { timeout: 20000 } );
 
 		const card = await page.evaluate( () => ( {
-			titles: Array.from( document.querySelectorAll( '.minn-order-panel .minn-side-title' ) ).map( ( e ) => e.textContent.trim() ),
+			titles: Array.from( document.querySelectorAll( '.minn-order-sec .minn-side-title' ) ).map( ( e ) => e.textContent.trim() ),
 			up: !! document.querySelector( '[data-plac="upsell_ids"]' ),
 			cross: !! document.querySelector( '[data-plac="cross_sell_ids"]' ),
 		} ) );

--- a/tests/product-organization.test.js
+++ b/tests/product-organization.test.js
@@ -77,6 +77,102 @@ const { BASE, launch, login, reporter, setSwitch } = require( './helpers' );
 		t.check( 'card carries categories, tags, brands, slug and featured',
 			card.cats && card.tags && card.brands && card.slug && card.featured, JSON.stringify( card ) );
 
+		// The field opens into a list, the way Shopify's collections field
+		// does: what exists is visible without guessing at a search term, and
+		// each row says whether the product is in it.
+		await page.click( '[data-ptac="categories"] .minn-ac-input' );
+		await page.waitForSelector( '[data-ptac="categories"] [data-ptpick]', { timeout: 20000 } );
+		const listed = await page.evaluate( ( name ) => {
+			const rows = Array.from( document.querySelectorAll( '[data-ptac="categories"] [data-ptpick]' ) );
+			const mine = rows.find( ( r ) => ( r.dataset.ptname || '' ) === name );
+			return {
+				count: rows.length,
+				boxes: rows.filter( ( r ) => r.querySelector( '.minn-check' ) ).length,
+				mine: !! mine,
+				mineOn: !! mine && mine.getAttribute( 'aria-selected' ) === 'true',
+				add: !! document.querySelector( '[data-ptac="categories"] [data-ptadd]' ),
+			};
+		}, catName );
+		t.check( 'clicking the field lists the categories without typing',
+			listed.count >= 1 && listed.mine, JSON.stringify( listed ) );
+		t.check( 'every row carries a tick box, unticked when not assigned',
+			listed.boxes === listed.count && ! listed.mineOn, JSON.stringify( listed ) );
+		t.check( 'a hierarchy offers no Add new, because a typo would land in it',
+			! listed.add, JSON.stringify( listed ) );
+
+		const tickRow = ( name ) => page.evaluate( ( n ) => {
+			const row = Array.from( document.querySelectorAll( '[data-ptac="categories"] [data-ptpick]' ) )
+				.find( ( r ) => ( r.dataset.ptname || '' ) === n );
+			if ( ! row ) return false;
+			row.dispatchEvent( new MouseEvent( 'mousedown', { bubbles: true, cancelable: true } ) );
+			return true;
+		}, name );
+		await tickRow( catName );
+		await page.waitForTimeout( 250 );
+		const afterTick = await page.evaluate( ( name ) => {
+			const panel = document.querySelector( '[data-ptac="categories"] .minn-ac-panel' );
+			const row = Array.from( document.querySelectorAll( '[data-ptac="categories"] [data-ptpick]' ) )
+				.find( ( r ) => ( r.dataset.ptname || '' ) === name );
+			return {
+				open: !! panel && ! panel.hidden,
+				on: !! row && row.getAttribute( 'aria-selected' ) === 'true',
+				chips: Array.from( document.querySelectorAll( '[data-ptchips="categories"] [data-ptchip]' ) ).map( ( c ) => c.textContent.trim() ),
+			};
+		}, catName );
+		t.check( 'ticking a row adds the chip and leaves the list open',
+			afterTick.open && afterTick.on && afterTick.chips.some( ( c ) => c.includes( catName ) ),
+			JSON.stringify( afterTick ) );
+		await tickRow( catName );
+		await page.waitForTimeout( 250 );
+		const afterUntick = await page.evaluate( ( name ) => {
+			const row = Array.from( document.querySelectorAll( '[data-ptac="categories"] [data-ptpick]' ) )
+				.find( ( r ) => ( r.dataset.ptname || '' ) === name );
+			return {
+				on: !! row && row.getAttribute( 'aria-selected' ) === 'true',
+				chips: Array.from( document.querySelectorAll( '[data-ptchips="categories"] [data-ptchip]' ) ).map( ( c ) => c.textContent.trim() ),
+			};
+		}, catName );
+		t.check( 'ticking it again takes the product back out',
+			! afterUntick.on && ! afterUntick.chips.some( ( c ) => c.includes( catName ) ),
+			JSON.stringify( afterUntick ) );
+
+		// A flat taxonomy can be added to from the list itself. Close the open
+		// panel first: it is drawn over the field below it, so a click there
+		// would land on a category row.
+		await page.click( '#minn-p-name' );
+		await page.waitForTimeout( 250 );
+		await page.click( '[data-ptac="tags"] .minn-ac-input' );
+		await page.waitForTimeout( 800 );
+		t.check( 'a flat taxonomy offers Add new in the list',
+			!! ( await page.$( '[data-ptac="tags"] [data-ptadd]' ) ), '' );
+		await page.click( '#minn-p-name' );
+		await page.waitForTimeout( 200 );
+
+		// Anything that goes to the server says so while it is going. Delayed
+		// on purpose: a local request answers too fast to observe otherwise.
+		await page.route( '**/wc/v3/products/categories**', async ( route ) => {
+			await new Promise( ( r ) => setTimeout( r, 1200 ) );
+			await route.continue();
+		} );
+		await page.goto( BASE + '/minn-admin/products/' + id, { waitUntil: 'domcontentloaded' } );
+		await page.waitForSelector( '#minn-p-slug', { timeout: 20000 } );
+		await page.click( '[data-ptac="categories"] .minn-ac-input' );
+		await page.waitForTimeout( 300 );
+		const busy = await page.evaluate( () => {
+			const w = document.querySelector( '[data-ptac="categories"]' );
+			return { loading: !! w && w.classList.contains( 'is-loading' ) };
+		} );
+		t.check( 'a field waiting on the server shows it is working', busy.loading, JSON.stringify( busy ) );
+		await page.waitForSelector( '[data-ptac="categories"] [data-ptpick]', { timeout: 20000 } );
+		const settled = await page.evaluate( () => {
+			const w = document.querySelector( '[data-ptac="categories"]' );
+			return !! w && w.classList.contains( 'is-loading' );
+		} );
+		t.check( 'and stops showing it once the answer lands', ! settled, String( settled ) );
+		await page.unroute( '**/wc/v3/products/categories**' );
+		await page.click( '#minn-p-name' );
+		await page.waitForTimeout( 200 );
+
 		// Categories: type, pick from the suggest panel.
 		await page.fill( '[data-ptac="categories"] .minn-ac-input', 'Minn Outerwear' );
 		await page.waitForSelector( '[data-ptac="categories"] [data-ptpick]', { timeout: 15000 } );

--- a/tests/product-organization.test.js
+++ b/tests/product-organization.test.js
@@ -37,8 +37,12 @@ const { BASE, launch, login, reporter, setSwitch } = require( './helpers' );
 	const catName = 'Minn Outerwear ' + suffix;
 	const tagName = 'minnwave' + suffix;
 	const brandName = 'Minnbrand ' + suffix;
+	const childCatName = 'Minn Parkas ' + suffix;
+	const dialogTagName = 'minndialog' + suffix;
 	let id = null;
 	let catId = null;
+	let childCatId = null;
+	let dialogTagId = null;
 	let madeTagId = null;
 	let madeBrandId = null;
 	try {
@@ -97,8 +101,7 @@ const { BASE, launch, login, reporter, setSwitch } = require( './helpers' );
 			listed.count >= 1 && listed.mine, JSON.stringify( listed ) );
 		t.check( 'every row carries a tick box, unticked when not assigned',
 			listed.boxes === listed.count && ! listed.mineOn, JSON.stringify( listed ) );
-		t.check( 'a hierarchy offers no Add new, because a typo would land in it',
-			! listed.add, JSON.stringify( listed ) );
+		t.check( 'the list offers a way to add a term', listed.add, JSON.stringify( listed ) );
 
 		const tickRow = ( name ) => page.evaluate( ( n ) => {
 			const row = Array.from( document.querySelectorAll( '[data-ptac="categories"] [data-ptpick]' ) )
@@ -136,15 +139,95 @@ const { BASE, launch, login, reporter, setSwitch } = require( './helpers' );
 			! afterUntick.on && ! afterUntick.chips.some( ( c ) => c.includes( catName ) ),
 			JSON.stringify( afterUntick ) );
 
-		// A flat taxonomy can be added to from the list itself. Close the open
-		// panel first: it is drawn over the field below it, so a click there
-		// would land on a category row.
-		await page.click( '#minn-p-name' );
-		await page.waitForTimeout( 250 );
-		await page.click( '[data-ptac="tags"] .minn-ac-input' );
-		await page.waitForTimeout( 800 );
-		t.check( 'a flat taxonomy offers Add new in the list',
-			!! ( await page.$( '[data-ptac="tags"] [data-ptadd]' ) ), '' );
+		// Add new opens a dialog rather than doing something invisible. The
+		// name is typed there, deliberately, which is what makes creating a
+		// category safe enough to offer at all.
+		const openAdd = async ( key ) => {
+			await page.click( '#minn-p-name' );
+			await page.waitForTimeout( 250 );
+			await page.click( `[data-ptac="${ key }"] .minn-ac-input` );
+			await page.waitForSelector( `[data-ptac="${ key }"] [data-ptadd]`, { timeout: 20000 } );
+			// Wait for the list to settle before measuring: rows landing under
+			// the footer move it, and a click aimed at where it used to be
+			// hits a row instead.
+			await page.waitForFunction(
+				( k ) => ! document.querySelector( `[data-ptac="${ k }"]` ).classList.contains( 'is-loading' ),
+				key, { timeout: 20000 } );
+			await page.waitForTimeout( 150 );
+			// A real click, scrolled into view first: the panel's foot can sit
+			// below the fold, and raw mouse coordinates do not scroll. The row
+			// is bound on mousedown (to survive the blur), so a dispatched
+			// event would not prove a reader can reach it.
+			await ( await page.$( `[data-ptac="${ key }"] [data-ptadd]` ) ).click();
+			await page.waitForSelector( '#minn-term-dialog', { timeout: 15000 } );
+		};
+
+		await openAdd( 'categories' );
+		const dialog = await page.evaluate( () => {
+			const d = document.querySelector( '#minn-term-dialog' );
+			return {
+				name: !! document.querySelector( '#minn-term-name' ),
+				parent: !! document.querySelector( '#minn-term-dialog [data-termparent]' ),
+				create: !! document.querySelector( '#minn-term-dialog [data-term-create]' ),
+				title: ( ( d.querySelector( '.minn-confirm-title' ) || {} ).textContent || '' ).trim(),
+			};
+		} );
+		t.check( 'Add new opens a dialog with a name field',
+			dialog.name && dialog.create, JSON.stringify( dialog ) );
+		t.check( 'a hierarchy also offers a parent to file it under',
+			dialog.parent, JSON.stringify( dialog ) );
+		t.check( 'the dialog says which kind of term it makes',
+			/categor/i.test( dialog.title ), dialog.title );
+
+		// Escape leaves nothing behind.
+		const catsBeforeCancel = ( ( await api( 'wc/v3/products/categories?per_page=100&_fields=id' ) ).body || [] ).length;
+		await page.fill( '#minn-term-name', 'Abandoned ' + suffix );
+		await page.keyboard.press( 'Escape' );
+		await page.waitForTimeout( 400 );
+		const catsAfterCancel = ( ( await api( 'wc/v3/products/categories?per_page=100&_fields=id' ) ).body || [] ).length;
+		t.check( 'cancelling the dialog creates nothing',
+			! ( await page.$( '#minn-term-dialog' ) ) && catsAfterCancel === catsBeforeCancel,
+			`${ catsBeforeCancel } -> ${ catsAfterCancel }` );
+
+		// Create for real, under the fixture category as parent.
+		await openAdd( 'categories' );
+		await page.fill( '#minn-term-name', childCatName );
+		await page.click( '#minn-term-dialog [data-termparent] .minn-ac-input' );
+		await page.waitForSelector( '#minn-term-dialog [data-termparent] .minn-ac-item', { timeout: 20000 } );
+		await page.evaluate( ( name ) => {
+			const row = Array.from( document.querySelectorAll( '#minn-term-dialog [data-termparent] .minn-ac-item' ) )
+				.find( ( r ) => ( r.textContent || '' ).trim() === name );
+			if ( row ) row.dispatchEvent( new MouseEvent( 'mousedown', { bubbles: true, cancelable: true } ) );
+		}, catName );
+		await page.click( '#minn-term-dialog [data-term-create]' );
+		await page.waitForFunction( () => ! document.querySelector( '#minn-term-dialog' ), null, { timeout: 20000 } );
+		await page.waitForTimeout( 300 );
+		const madeCat = ( ( await api( `wc/v3/products/categories?search=${ encodeURIComponent( childCatName ) }&per_page=10&_fields=id,name,parent` ) ).body || [] )[ 0 ];
+		childCatId = madeCat && madeCat.id;
+		t.check( 'the dialog creates the term in WooCommerce', !! childCatId, JSON.stringify( madeCat ) );
+		t.check( 'and files it under the parent that was chosen',
+			!! madeCat && madeCat.parent === catId, JSON.stringify( madeCat ) );
+		const afterCreate = await page.evaluate( () => Array.from(
+			document.querySelectorAll( '[data-ptchips="categories"] [data-ptchip]' ) ).map( ( c ) => c.textContent.trim() ) );
+		t.check( 'the new term lands on the product, already ticked',
+			afterCreate.some( ( c ) => c.includes( childCatName ) ), JSON.stringify( afterCreate ) );
+
+		// The same door for a flat taxonomy, minus the parent.
+		await openAdd( 'tags' );
+		const flatDialog = await page.evaluate( () => ( {
+			name: !! document.querySelector( '#minn-term-name' ),
+			parent: !! document.querySelector( '#minn-term-dialog [data-termparent]' ),
+		} ) );
+		t.check( 'a flat taxonomy gets the dialog without a parent',
+			flatDialog.name && ! flatDialog.parent, JSON.stringify( flatDialog ) );
+		await page.fill( '#minn-term-name', dialogTagName );
+		await page.click( '#minn-term-dialog [data-term-create]' );
+		await page.waitForFunction( () => ! document.querySelector( '#minn-term-dialog' ), null, { timeout: 20000 } );
+		await page.waitForTimeout( 300 );
+		const tagChipsAfter = await page.evaluate( () => Array.from(
+			document.querySelectorAll( '[data-ptchips="tags"] [data-ptchip]' ) ).map( ( c ) => c.textContent.trim() ) );
+		t.check( 'a tag made in the dialog lands on the product',
+			tagChipsAfter.some( ( c ) => c.includes( dialogTagName ) ), JSON.stringify( tagChipsAfter ) );
 		await page.click( '#minn-p-name' );
 		await page.waitForTimeout( 200 );
 
@@ -272,9 +355,16 @@ const { BASE, launch, login, reporter, setSwitch } = require( './helpers' );
 			JSON.stringify( ( unassigned.body || {} ).categories ) );
 	} finally {
 		if ( id ) await api( `wc/v3/products/${ id }?force=true`, { method: 'DELETE' } ).catch( () => null );
+		// The child goes before its parent: deleting a parent only reparents.
+		if ( childCatId ) await api( `wc/v3/products/categories/${ childCatId }?force=true`, { method: 'DELETE' } ).catch( () => null );
 		if ( catId ) await api( `wc/v3/products/categories/${ catId }?force=true`, { method: 'DELETE' } ).catch( () => null );
 		if ( madeTagId ) await api( `wc/v3/products/tags/${ madeTagId }?force=true`, { method: 'DELETE' } ).catch( () => null );
 		if ( madeBrandId ) await api( `wc/v3/products/brands/${ madeBrandId }?force=true`, { method: 'DELETE' } ).catch( () => null );
+		if ( ! dialogTagId ) {
+			const found = ( await api( `wc/v3/products/tags?search=${ encodeURIComponent( dialogTagName ) }&per_page=5&_fields=id` ) ).body;
+			dialogTagId = ( Array.isArray( found ) ? found : [] ).map( ( x ) => x.id )[ 0 ];
+		}
+		if ( dialogTagId ) await api( `wc/v3/products/tags/${ dialogTagId }?force=true`, { method: 'DELETE' } ).catch( () => null );
 	}
 
 	await t.done( browser, errors );

--- a/tests/product-organization.test.js
+++ b/tests/product-organization.test.js
@@ -66,7 +66,7 @@ const { BASE, launch, login, reporter, setSwitch } = require( './helpers' );
 		await page.waitForSelector( '#minn-p-slug', { timeout: 20000 } );
 
 		const card = await page.evaluate( () => ( {
-			titles: Array.from( document.querySelectorAll( '.minn-order-panel .minn-side-title' ) ).map( ( e ) => e.textContent.trim() ),
+			titles: Array.from( document.querySelectorAll( '.minn-order-sec .minn-side-title' ) ).map( ( e ) => e.textContent.trim() ),
 			cats: !! document.querySelector( '[data-ptac="categories"]' ),
 			tags: !! document.querySelector( '[data-ptac="tags"]' ),
 			brands: !! document.querySelector( '[data-ptac="brands"]' ),

--- a/tests/product-page.test.js
+++ b/tests/product-page.test.js
@@ -68,7 +68,8 @@ const { BASE, launch, login, reporter } = require( './helpers' );
 		} ) );
 		t.check( 'deep link renders the page, not a modal', head.page && ! head.modal, JSON.stringify( head ) );
 		t.check( 'page names the product', /Product page fixture/.test( head.title ), head.title );
-		t.check( 'page sub carries type, SKU and id', /simple/.test( head.sub ) && head.sub.includes( '#' + id ), head.sub );
+		// The type reads as its label ("Simple product"), not as the slug.
+		t.check( 'page sub carries type, SKU and id', /simple/i.test( head.sub ) && head.sub.includes( '#' + id ), head.sub );
 		t.check( 'page has the shared detail fields', head.save && head.sku && head.price, JSON.stringify( head ) );
 
 		// 2. Every choice on the page is a Minn combobox. A native select drops
@@ -84,6 +85,88 @@ const { BASE, launch, login, reporter } = require( './helpers' );
 			return !! btn && btn.classList.contains( 'active' );
 		} );
 		t.check( 'Products nav stays active on the detail page', navLit, '' );
+
+		// 4. The Shopify shape, measured rather than queried: a main column with
+		// a sidebar beside it, each section its own card. Asserting on drawn
+		// boxes is the point — the markup can carry both class names and still
+		// paint as one slab if the CSS never lands.
+		const boxes = () => page.evaluate( () => {
+			const box = ( el ) => {
+				if ( ! el ) return null;
+				const r = el.getBoundingClientRect();
+				return { x: Math.round( r.x ), y: Math.round( r.y ), w: Math.round( r.width ), right: Math.round( r.right ), bottom: Math.round( r.bottom ) };
+			};
+			const q = ( s ) => box( document.querySelector( s ) );
+			return {
+				main: q( '.minn-order-page .minn-order-main' ),
+				side: q( '.minn-order-page .minn-order-side' ),
+				pricing: q( '.minn-order-page [data-pcard="pricing"]' ),
+				status: q( '.minn-order-page [data-pcard="status"]' ),
+				org: q( '.minn-order-page [data-pcard="organization"]' ),
+				cards: document.querySelectorAll( '.minn-order-page .minn-order-sec' ).length,
+				slab: !! document.querySelector( '.minn-order-page .minn-order-grid' ),
+			};
+		} );
+		const lay = await boxes();
+		t.check( 'the page lays out a main column and a sidebar',
+			!! lay.main && !! lay.side && lay.side.w >= 300 && lay.side.w <= 380 && lay.main.w > lay.side.w,
+			JSON.stringify( { main: lay.main, side: lay.side } ) );
+		t.check( 'the sidebar sits beside the main column, not under it',
+			!! lay.main && !! lay.side && lay.side.x >= lay.main.right - 2 && Math.abs( lay.side.y - lay.main.y ) <= 8,
+			JSON.stringify( { main: lay.main, side: lay.side } ) );
+		t.check( 'Status and Organization ride in the sidebar',
+			!! lay.side && !! lay.status && !! lay.org
+				&& lay.status.x >= lay.side.x - 2 && lay.status.right <= lay.side.right + 2
+				&& lay.org.x >= lay.side.x - 2 && lay.org.right <= lay.side.right + 2,
+			JSON.stringify( { side: lay.side, status: lay.status, org: lay.org } ) );
+		t.check( 'Pricing rides in the main column',
+			!! lay.main && !! lay.pricing && lay.pricing.x >= lay.main.x - 2 && lay.pricing.right <= lay.main.right + 2,
+			JSON.stringify( { main: lay.main, pricing: lay.pricing } ) );
+		t.check( 'each section is its own card, not one slab',
+			lay.cards >= 6 && ! lay.slab, JSON.stringify( { cards: lay.cards, slab: lay.slab } ) );
+
+		// 5. The save bar: absent until something actually changes, reachable
+		// without scrolling once it is up, and able to put the page back.
+		const barState = () => page.evaluate( () => {
+			const bar = document.querySelector( '#minn-p-savebar' );
+			if ( ! bar ) return { present: false };
+			const r = bar.getBoundingClientRect();
+			return {
+				present: true,
+				shown: ! bar.hidden && r.height > 0 && bar.offsetParent !== null,
+				top: Math.round( r.top ), bottom: Math.round( r.bottom ), vh: window.innerHeight,
+				save: !! bar.querySelector( '#minn-product-save' ),
+				discard: !! bar.querySelector( '#minn-p-discard' ),
+			};
+		} );
+		const loadedName = await page.evaluate( () => ( document.querySelector( '#minn-p-name' ) || {} ).value || '' );
+		const barClean = await barState();
+		t.check( 'a page with no edits shows no save bar',
+			barClean.present && ! barClean.shown, JSON.stringify( barClean ) );
+		await page.fill( '#minn-p-name', loadedName + ' edited' );
+		await page.waitForTimeout( 200 );
+		const barDirty = await barState();
+		t.check( 'editing a field raises the save bar',
+			barDirty.shown && barDirty.save && barDirty.discard, JSON.stringify( barDirty ) );
+		t.check( 'the save bar is reachable without scrolling',
+			barDirty.shown && barDirty.bottom <= barDirty.vh + 2 && barDirty.top >= 0,
+			JSON.stringify( barDirty ) );
+		await page.click( '#minn-p-discard' );
+		await page.waitForTimeout( 300 );
+		const afterDiscard = await page.evaluate( () => ( document.querySelector( '#minn-p-name' ) || {} ).value || '' );
+		const barAfterDiscard = await barState();
+		t.check( 'discarding restores the loaded values and lowers the bar',
+			afterDiscard === loadedName && ! barAfterDiscard.shown,
+			JSON.stringify( { afterDiscard, bar: barAfterDiscard } ) );
+		// A switch is not typing: the change never fires an input event, so a
+		// listener that only watches inputs would miss it entirely.
+		await page.click( '#minn-p-featured' );
+		await page.waitForTimeout( 250 );
+		const barSwitch = await barState();
+		t.check( 'flipping a switch counts as a change too',
+			barSwitch.shown, JSON.stringify( barSwitch ) );
+		await page.click( '#minn-p-discard' );
+		await page.waitForTimeout( 300 );
 
 		// 3. Saving from the page persists and repaints the page (not a modal).
 		const newName = 'Product page renamed ' + suffix;
@@ -108,6 +191,8 @@ const { BASE, launch, login, reporter } = require( './helpers' );
 		t.check( 'save repaints the page in place',
 			stillPage.page && ! stillPage.modal && /renamed/.test( stillPage.title ),
 			JSON.stringify( stillPage ) );
+		const barSaved = await barState();
+		t.check( 'saving lowers the save bar', barSaved.present && ! barSaved.shown, JSON.stringify( barSaved ) );
 
 		// 4. Back goes to the list.
 		await page.click( '#minn-pp-back' );
@@ -134,6 +219,28 @@ const { BASE, launch, login, reporter } = require( './helpers' );
 				} ) );
 				t.check( 'eye opens the quick view without navigating',
 					qv.modal && /\/products$/.test( qv.path ), JSON.stringify( qv ) );
+				// One body, two hosts: the two-column grid is the page's, so the
+				// modal gets the same markup stacked in one column, and the save
+				// bar belongs to the page alone. The modal paints its chrome
+				// before the detail lands, so wait for a field, not the overlay.
+				await page.waitForSelector( '.minn-modal-overlay #minn-p-name', { timeout: 20000 } ).catch( () => null );
+				const qvShape = await page.evaluate( () => {
+					const m = document.querySelector( '.minn-modal-overlay .minn-order-main' );
+					const s = document.querySelector( '.minn-modal-overlay .minn-order-side' );
+					if ( ! m || ! s ) return null;
+					const a = m.getBoundingClientRect(), b = s.getBoundingClientRect();
+					return {
+						mx: Math.round( a.x ), sx: Math.round( b.x ),
+						sy: Math.round( b.y ), mb: Math.round( a.bottom ),
+						bar: !! document.querySelector( '.minn-modal-overlay #minn-p-savebar' ),
+						save: !! document.querySelector( '.minn-modal-overlay #minn-product-save' ),
+					};
+				} );
+				t.check( 'the quick view stacks the same body in one column',
+					!! qvShape && Math.abs( qvShape.mx - qvShape.sx ) <= 2 && qvShape.sy >= qvShape.mb - 2,
+					JSON.stringify( qvShape ) );
+				t.check( 'the quick view keeps its own Save, not the page bar',
+					!! qvShape && qvShape.save && ! qvShape.bar, JSON.stringify( qvShape ) );
 				await page.keyboard.press( 'Escape' );
 				await page.waitForTimeout( 300 );
 			}
@@ -168,6 +275,18 @@ const { BASE, launch, login, reporter } = require( './helpers' );
 		await page.waitForSelector( '#minn-p-name', { timeout: 20000 } );
 		const revisit = await page.evaluate( () => ( ( document.querySelector( '#minn-p-name' ) || {} ).value || '' ) );
 		t.check( 'revisiting refetches the product', /renamed/.test( revisit ), revisit );
+
+		// 8. Narrow: the sidebar drops under the main column rather than being
+		// squeezed beside it.
+		await page.setViewportSize( { width: 900, height: 800 } );
+		await page.waitForTimeout( 300 );
+		const narrow = await boxes();
+		t.check( 'a narrow viewport stacks the sidebar under the main column',
+			!! narrow.main && !! narrow.side
+				&& Math.abs( narrow.side.x - narrow.main.x ) <= 2
+				&& narrow.side.y >= narrow.main.bottom - 2,
+			JSON.stringify( { main: narrow.main, side: narrow.side } ) );
+		await page.setViewportSize( { width: 1280, height: 720 } );
 	} finally {
 		if ( id ) await api( `wc/v3/products/${ id }?force=true`, { method: 'DELETE' } ).catch( () => null );
 	}

--- a/tests/product-page.test.js
+++ b/tests/product-page.test.js
@@ -194,6 +194,20 @@ const { BASE, launch, login, reporter } = require( './helpers' );
 		const barSaved = await barState();
 		t.check( 'saving lowers the save bar', barSaved.present && ! barSaved.shown, JSON.stringify( barSaved ) );
 
+		// A sale price that is not below the regular one never reaches the
+		// server: WooCommerce takes it with a 200 and drops it without a word,
+		// so the save would report success and change nothing.
+		await page.fill( '#minn-p-sale', '99.00' );
+		await page.click( '#minn-product-save' );
+		await page.waitForTimeout( 600 );
+		const saleToast = await page.evaluate( () => Array.from( document.querySelectorAll( '.minn-toast' ) ).map( ( x ) => x.textContent.trim() ).join( ' | ' ) );
+		const notSaved = await api( `wc/v3/products/${ id }?_fields=id,sale_price` );
+		t.check( 'a sale price above the regular price is refused before the save',
+			/lower/i.test( saleToast ) && ! ( ( notSaved.body || {} ).sale_price ),
+			JSON.stringify( { saleToast, sale: ( notSaved.body || {} ).sale_price } ) );
+		await page.fill( '#minn-p-sale', '' );
+		await page.waitForTimeout( 200 );
+
 		// 4. Back goes to the list.
 		await page.click( '#minn-pp-back' );
 		await page.waitForSelector( '.minn-table-row[data-product]', { timeout: 20000 } );

--- a/tests/product-page.test.js
+++ b/tests/product-page.test.js
@@ -268,6 +268,29 @@ const { BASE, launch, login, reporter } = require( './helpers' );
 			await page.waitForSelector( '#minn-editor-body, .minn-editor-body', { timeout: 20000 } ).catch( () => null );
 			t.check( 'the product opens in Minn\'s editor',
 				!! ( await page.$( '#minn-editor-body, .minn-editor-body' ) ), '' );
+
+			// Arriving from a product leaves a trail, so the editor offers the
+			// way back. Without it the description is a one-way door: the
+			// editor's only exits are the nav and the browser's own Back.
+			const backLabel = await page.evaluate( () => {
+				const b = document.querySelector( '#minn-editor-back' );
+				return b ? b.textContent.trim() : null;
+			} );
+			t.check( 'the editor offers a way back to the product',
+				!! backLabel && /renamed/.test( backLabel ), String( backLabel ) );
+			if ( backLabel ) {
+				await page.click( '#minn-editor-back' );
+				await page.waitForFunction( ( pid ) => location.pathname.endsWith( '/products/' + pid ), id, { timeout: 15000 } ).catch( () => null );
+				t.check( 'back from the editor returns to the product',
+					await page.evaluate( ( pid ) => location.pathname.endsWith( '/products/' + pid ), id ),
+					await page.evaluate( () => location.pathname ) );
+			}
+			// A deep link into the editor left no trail, so it offers no back:
+			// the button follows where the reader came from, not the post type.
+			await page.goto( BASE + '/minn-admin/editor/product/' + id, { waitUntil: 'domcontentloaded' } );
+			await page.waitForSelector( '#minn-editor-body, .minn-editor-body', { timeout: 20000 } ).catch( () => null );
+			t.check( 'a deep link into the editor offers no stale back',
+				! ( await page.$( '#minn-editor-back' ) ), '' );
 		}
 
 		// 7. A stale page state does not leak into the next product.

--- a/tests/product-types.test.js
+++ b/tests/product-types.test.js
@@ -36,7 +36,7 @@ const { BASE, launch, login, reporter, pickCombo, setSwitch, switchOn } = requir
 	}, { path, opts } );
 
 	const cards = () => page.evaluate( () => Array.from(
-		document.querySelectorAll( '.minn-order-panel .minn-side-title' ) ).map( ( e ) => e.textContent.trim() ) );
+		document.querySelectorAll( '.minn-order-sec .minn-side-title' ) ).map( ( e ) => e.textContent.trim() ) );
 
 	const suffix = Date.now();
 	let id = null;
@@ -90,7 +90,7 @@ const { BASE, launch, login, reporter, pickCombo, setSwitch, switchOn } = requir
 		await setSwitch( page, '#minn-p-downloadable', true );
 		await page.waitForFunction( () => !! document.querySelector( '#minn-p-downloads' ), null, { timeout: 15000 } ).catch( () => null );
 		const afterDl = await page.evaluate( () => ( {
-			cards: Array.from( document.querySelectorAll( '.minn-order-panel .minn-side-title' ) ).map( ( e ) => e.textContent.trim() ),
+			cards: Array.from( document.querySelectorAll( '.minn-order-sec .minn-side-title' ) ).map( ( e ) => e.textContent.trim() ),
 			sku: ( document.querySelector( '#minn-p-sku' ) || {} ).value,
 			add: !! document.querySelector( '#minn-p-dl-add' ),
 			limit: !! document.querySelector( '#minn-p-dllimit' ),

--- a/tests/product-variations.test.js
+++ b/tests/product-variations.test.js
@@ -91,10 +91,81 @@ const { BASE, launch, login, reporter } = require( './helpers' );
 		const rows = await page.evaluate( () => document.querySelectorAll( '.minn-pvar-row' ).length );
 		t.check( 'generating builds one row per attribute value', rows === 2, String( rows ) );
 
-		// Price them, then save through the page's own button.
-		await page.fill( '[data-pvarreg="0"]', '19.00' );
-		await page.fill( '[data-pvarreg="1"]', '24.00' );
-		await page.fill( '[data-pvarsku="0"]', 'VAR-S-' + suffix );
+		// The card is a list of variants, not a wall of inputs: each row reads
+		// as a variant, and the editing happens behind it.
+		const listShape = await page.evaluate( () => {
+			const row = document.querySelector( '.minn-pvar-row' );
+			return {
+				openable: document.querySelectorAll( '.minn-pvar-row[data-pvaropen]' ).length,
+				inlineInputs: document.querySelectorAll( '#minn-p-variations input' ).length,
+				name: ( ( row.querySelector( '.minn-pvar-name' ) || {} ).textContent || '' ).trim(),
+				price: !! row.querySelector( '.minn-pvar-price' ),
+				avail: !! row.querySelector( '.minn-pvar-avail' ),
+				thumb: !! row.querySelector( '.minn-pvar-thumb' ),
+				badge: !! row.querySelector( '.minn-pvar-new' ),
+			};
+		} );
+		t.check( 'the card lists variants rather than rows of inputs',
+			listShape.openable === 2 && listShape.inlineInputs === 0, JSON.stringify( listShape ) );
+		t.check( 'a row carries the variant, a picture slot, price and availability',
+			/Small|Large/.test( listShape.name ) && listShape.price && listShape.avail && listShape.thumb,
+			JSON.stringify( listShape ) );
+		t.check( 'an unsaved variation is badged as new', listShape.badge, JSON.stringify( listShape ) );
+
+		// Everything modifiable lives in the variant's own editor.
+		await ( await page.$( '[data-pvaropen="0"]' ) ).click();
+		await page.waitForSelector( '#minn-var-dialog', { timeout: 15000 } );
+		const dlg = await page.evaluate( () => ( {
+			title: ( ( document.querySelector( '#minn-var-dialog .minn-confirm-title' ) || {} ).textContent || '' ).trim(),
+			sku: !! document.querySelector( '#minn-var-sku' ),
+			regular: !! document.querySelector( '#minn-var-regular' ),
+			sale: !! document.querySelector( '#minn-var-sale' ),
+			stock: !! document.querySelector( '#minn-var-dialog [data-varstock]' ),
+			track: !! document.querySelector( '#minn-var-track' ),
+			axes: document.querySelectorAll( '#minn-var-dialog [data-varaxis]' ).length,
+			image: !! document.querySelector( '#minn-var-img-pick' ),
+			natives: document.querySelectorAll( '#minn-var-dialog select' ).length,
+		} ) );
+		t.check( 'the editor opens on the variant it was asked for',
+			/Small|Large/.test( dlg.title ), dlg.title );
+		t.check( 'and holds everything modifiable about it',
+			dlg.sku && dlg.regular && dlg.sale && dlg.stock && dlg.track && dlg.axes === 1 && dlg.image,
+			JSON.stringify( dlg ) );
+		t.check( 'the editor uses Minn comboboxes, not native selects',
+			dlg.natives === 0, String( dlg.natives ) );
+		// Drawn, not just marked hidden: a button's own display beats the
+		// hidden attribute, which is how this shipped visible the first time.
+		const removeShown = await page.evaluate( () => {
+			const b = document.querySelector( '#minn-var-img-x' );
+			return !! b && b.getBoundingClientRect().height > 0;
+		} );
+		t.check( 'a variant with no picture offers no Remove image', ! removeShown, String( removeShown ) );
+
+		// Cancel is not a save: what was typed goes nowhere.
+		await page.fill( '#minn-var-regular', '999.00' );
+		await page.click( '#minn-var-dialog [data-var-cancel]' );
+		await page.waitForFunction( () => ! document.querySelector( '#minn-var-dialog' ), null, { timeout: 15000 } );
+		const afterCancel = await page.evaluate( () => Array.from(
+			document.querySelectorAll( '.minn-pvar-price' ) ).map( ( e ) => e.textContent.trim() ).join( '|' ) );
+		t.check( 'cancelling the editor changes nothing', ! /999/.test( afterCancel ), afterCancel );
+
+		// Price them through the editor, then save through the page's button.
+		const editVariant = async ( i, fields ) => {
+			await ( await page.$( `[data-pvaropen="${ i }"]` ) ).click();
+			await page.waitForSelector( '#minn-var-dialog', { timeout: 15000 } );
+			if ( fields.regular != null ) await page.fill( '#minn-var-regular', fields.regular );
+			if ( fields.sku != null ) await page.fill( '#minn-var-sku', fields.sku );
+			await page.click( '#minn-var-dialog [data-var-done]' );
+			await page.waitForFunction( () => ! document.querySelector( '#minn-var-dialog' ), null, { timeout: 15000 } );
+			await page.waitForTimeout( 150 );
+		};
+		await editVariant( 0, { regular: '19.00', sku: 'VAR-S-' + suffix } );
+		await editVariant( 1, { regular: '24.00' } );
+		const rowPrices = await page.evaluate( () => Array.from(
+			document.querySelectorAll( '.minn-pvar-price' ) ).map( ( e ) => e.textContent.trim() ) );
+		t.check( 'Done writes what was typed back onto the row',
+			rowPrices.some( ( p ) => /19\.00/.test( p ) ) && rowPrices.some( ( p ) => /24\.00/.test( p ) ),
+			JSON.stringify( rowPrices ) );
 		await save();
 
 		const saved = await api( `wc/v3/products/${ id }/variations?per_page=100&_fields=id,sku,regular_price,attributes` );
@@ -110,11 +181,15 @@ const { BASE, launch, login, reporter } = require( './helpers' );
 			list.every( ( v ) => ( v.attributes || [] ).some( ( a ) => /Small|Large/.test( a.option || '' ) ) ),
 			JSON.stringify( list.map( ( v ) => v.attributes ) ) );
 
+		// Saved rows lose the New badge: it means "not on the server yet".
+		const badgesAfterSave = await page.evaluate( () => document.querySelectorAll( '.minn-pvar-new' ).length );
+		t.check( 'a saved variation is no longer badged new', badgesAfterSave === 0, String( badgesAfterSave ) );
+
 		// Saving twice must not duplicate: created rows come back with ids.
 		// The second save needs a real edit to reach: the page's save bar is
 		// down while the form matches what was stored, which is also the point
 		// of the check — the rows that come back carry ids, so this updates.
-		await page.fill( '[data-pvarreg="0"]', '19.50' );
+		await editVariant( 0, { regular: '19.50' } );
 		await save();
 		const again = await api( `wc/v3/products/${ id }/variations?per_page=100&_fields=id` );
 		t.check( 'saving twice does not duplicate the variations',
@@ -131,19 +206,50 @@ const { BASE, launch, login, reporter } = require( './helpers' );
 		await page.waitForSelector( '.minn-pvar-row', { timeout: 20000 } );
 		const repop = await page.evaluate( () => ( {
 			rows: document.querySelectorAll( '.minn-pvar-row' ).length,
-			prices: Array.from( document.querySelectorAll( '[data-pvarreg]' ) ).map( ( i ) => i.value ),
-			// The axis is a combobox, so the machine value is on the dataset.
-			axisPicked: Array.from( document.querySelectorAll( '[data-pvaraxis] .minn-ac-input' ) ).map( ( s ) => s.dataset.acValue ),
+			prices: Array.from( document.querySelectorAll( '.minn-pvar-price' ) ).map( ( e ) => e.textContent.trim() ),
+			names: Array.from( document.querySelectorAll( '.minn-pvar-name' ) ).map( ( e ) => e.textContent.trim() ),
 			nativeSelects: document.querySelectorAll( '#minn-p-variations select' ).length,
 		} ) );
 		t.check( 'variations repopulate with their prices and values',
-			repop.rows === 2 && repop.prices.includes( '19.00' )
-			&& repop.axisPicked.filter( Boolean ).length === 2, JSON.stringify( repop ) );
+			repop.rows === 2 && repop.prices.some( ( p ) => /19\.50/.test( p ) )
+			&& repop.names.filter( ( n ) => /Small|Large/.test( n ) ).length === 2, JSON.stringify( repop ) );
 		t.check( 'variation rows use Minn comboboxes, not native selects',
 			repop.nativeSelects === 0, String( repop.nativeSelects ) );
 
-		await page.fill( '[data-pvarreg="0"]', '21.50' );
+		// A picture for one variant, picked from the library through the
+		// editor. The picker opens over the dialog, which is the part worth
+		// proving: a modal inside a modal is where z-index goes wrong.
+		await ( await page.$( '[data-pvaropen="0"]' ) ).click();
+		await page.waitForSelector( '#minn-var-dialog', { timeout: 15000 } );
+		await page.click( '#minn-var-img-pick' );
+		await page.waitForSelector( '.minn-picker-item', { timeout: 20000 } );
+		const pickerOnTop = await page.evaluate( () => {
+			const pick = document.querySelector( '#minn-modal-overlay' );
+			const dlg = document.querySelector( '#minn-var-dialog' );
+			if ( ! pick || ! dlg ) return null;
+			const z = ( el ) => parseInt( getComputedStyle( el ).zIndex, 10 ) || 0;
+			const r = pick.querySelector( '.minn-picker-item' ).getBoundingClientRect();
+			const hit = document.elementFromPoint( r.x + r.width / 2, r.y + r.height / 2 );
+			return { pickerZ: z( pick ), dialogZ: z( dlg ), reachable: !! hit && !! hit.closest( '.minn-picker-item' ) };
+		} );
+		t.check( 'the picker opens above the variant editor, clickable',
+			!! pickerOnTop && pickerOnTop.pickerZ > pickerOnTop.dialogZ && pickerOnTop.reachable,
+			JSON.stringify( pickerOnTop ) );
+		await page.click( '.minn-picker-item' );
+		await page.waitForFunction( () => ! document.querySelector( '.minn-picker-item' ), null, { timeout: 15000 } ).catch( () => null );
+		await page.waitForTimeout( 300 );
+		const gotThumb = await page.evaluate( () => !! document.querySelector( '#minn-var-image img' ) );
+		t.check( 'the picked image shows in the editor', gotThumb, '' );
+		await page.fill( '#minn-var-regular', '21.50' );
+		await page.click( '#minn-var-dialog [data-var-done]' );
+		await page.waitForFunction( () => ! document.querySelector( '#minn-var-dialog' ), null, { timeout: 15000 } );
+		const rowThumb = await page.evaluate( () => !! document.querySelector( '.minn-pvar-thumb img' ) );
+		t.check( 'and on the row it came from', rowThumb, '' );
 		await save();
+		const withImage = await api( `wc/v3/products/${ id }/variations?per_page=100&_fields=id,image,regular_price` );
+		t.check( 'the variant picture saves',
+			( withImage.body || [] ).some( ( v ) => v.image && v.image.id ),
+			JSON.stringify( ( withImage.body || [] ).map( ( v ) => ( v.image ? v.image.id : null ) ) ) );
 		const edited = await api( `wc/v3/products/${ id }/variations?per_page=100&_fields=id,regular_price` );
 		t.check( 'editing an existing variation updates it',
 			( edited.body || [] ).some( ( v ) => String( v.regular_price ) === '21.50' )

--- a/tests/product-variations.test.js
+++ b/tests/product-variations.test.js
@@ -44,6 +44,7 @@ const { BASE, launch, login, reporter } = require( './helpers' );
 
 	const suffix = Date.now();
 	let id = null;
+	let rivalId = null;
 	try {
 		const defs = await api( 'wc/v3/products/attributes?_fields=id,name' );
 		const attr = ( defs.body || [] )[ 0 ];
@@ -181,6 +182,88 @@ const { BASE, launch, login, reporter } = require( './helpers' );
 			list.every( ( v ) => ( v.attributes || [] ).some( ( a ) => /Small|Large/.test( a.option || '' ) ) ),
 			JSON.stringify( list.map( ( v ) => v.attributes ) ) );
 
+		// A sale price that is not BELOW the regular price is refused here,
+		// because WooCommerce does not refuse it: it answers 200 and drops the
+		// sale price without a word, so the reader would get a success toast
+		// and no sale at all.
+		const doneAndRead = async () => {
+			await page.click( '#minn-var-dialog [data-var-done]' );
+			await page.waitForTimeout( 300 );
+			return page.evaluate( () => {
+				const d = document.querySelector( '#minn-var-dialog' );
+				const err = d && d.querySelector( '.minn-var-error' );
+				return { open: !! d, msg: err && ! err.hidden ? err.textContent.trim() : '' };
+			} );
+		};
+		await ( await page.$( '[data-pvaropen="0"]' ) ).click();
+		await page.waitForSelector( '#minn-var-dialog', { timeout: 15000 } );
+		await page.fill( '#minn-var-regular', '20.00' );
+		await page.fill( '#minn-var-sale', '30.00' );
+		const higher = await doneAndRead();
+		t.check( 'a sale price above the regular price is refused',
+			higher.open && /lower/i.test( higher.msg ), JSON.stringify( higher ) );
+		await page.fill( '#minn-var-sale', '20.00' );
+		const equal = await doneAndRead();
+		t.check( 'and the same price is not lower either',
+			equal.open && /lower/i.test( equal.msg ), JSON.stringify( equal ) );
+
+		// Two variants of one product cannot share a SKU. That check is local,
+		// so it costs nothing and answers before a save.
+		await page.fill( '#minn-var-sale', '' );
+		await page.fill( '#minn-var-sku', 'VAR-S-' + suffix );
+		const clash = await doneAndRead();
+		t.check( 'a SKU another variation already uses is refused',
+			clash.open && /SKU/i.test( clash.msg ), JSON.stringify( clash ) );
+		await page.fill( '#minn-var-sku', 'VAR-L-' + suffix );
+		await page.fill( '#minn-var-sale', '15.00' );
+		const good = await doneAndRead();
+		t.check( 'a lower sale price and a free SKU go through',
+			! good.open, JSON.stringify( good ) );
+		await save();
+		const priced = await api( `wc/v3/products/${ id }/variations?per_page=100&_fields=id,sku,sale_price` );
+		t.check( 'the sale price and SKU that passed are what WooCommerce stored',
+			( priced.body || [] ).some( ( v ) => String( v.sale_price ) === '15.00' && v.sku === 'VAR-L-' + suffix ),
+			JSON.stringify( ( priced.body || [] ).map( ( v ) => [ v.sku, v.sale_price ] ) ) );
+
+		// A SKU taken by ANOTHER product is not something the page can know, so
+		// the refusal has to come back from the save. WooCommerce hides it
+		// inside a 200 batch response; it must still reach the reader.
+		const rival = await api( 'wc/v3/products', {
+			method: 'POST',
+			body: JSON.stringify( { name: 'SKU rival ' + suffix, type: 'simple', status: 'draft', sku: 'RIVAL-' + suffix } ),
+		} );
+		rivalId = rival.body && rival.body.id;
+		await ( await page.$( '[data-pvaropen="0"]' ) ).click();
+		await page.waitForSelector( '#minn-var-dialog', { timeout: 15000 } );
+		await page.fill( '#minn-var-sku', 'RIVAL-' + suffix );
+		await page.click( '#minn-var-dialog [data-var-done]' );
+		await page.waitForFunction( () => ! document.querySelector( '#minn-var-dialog' ), null, { timeout: 15000 } );
+		await page.click( '#minn-product-save' );
+		await page.waitForFunction(
+			() => Array.from( document.querySelectorAll( '.minn-toast' ) ).some( ( x ) => /SKU/i.test( x.textContent ) ),
+			null, { timeout: 25000 } ).catch( () => null );
+		const toast = await page.evaluate( () => Array.from( document.querySelectorAll( '.minn-toast' ) ).map( ( x ) => x.textContent.trim() ).join( ' | ' ) );
+		t.check( 'a SKU refused inside the batch reaches the reader',
+			/SKU/i.test( toast ), toast );
+		const stillFree = await api( `wc/v3/products/${ id }/variations?per_page=100&_fields=id,sku` );
+		t.check( 'and the variation kept the SKU it had',
+			( stillFree.body || [] ).some( ( v ) => v.sku === 'VAR-L-' + suffix ),
+			JSON.stringify( ( stillFree.body || [] ).map( ( v ) => v.sku ) ) );
+		// Put the SKU back. No save follows on purpose: the batch refused that
+		// item, so the server still holds this value, and typing it back makes
+		// the page clean again — which the save bar going down proves.
+		await ( await page.$( '[data-pvaropen="0"]' ) ).click();
+		await page.waitForSelector( '#minn-var-dialog', { timeout: 15000 } );
+		await page.fill( '#minn-var-sku', 'VAR-L-' + suffix );
+		await page.click( '#minn-var-dialog [data-var-done]' );
+		await page.waitForFunction( () => ! document.querySelector( '#minn-var-dialog' ), null, { timeout: 15000 } );
+		await page.waitForTimeout( 300 );
+		const barDown = await page.evaluate( () => {
+			const b = document.querySelector( '#minn-p-savebar' );
+			return !! b && b.hidden;
+		} );
+		t.check( 'undoing the refused edit leaves nothing to save', barDown, String( barDown ) );
+
 		// Saved rows lose the New badge: it means "not on the server yet".
 		const badgesAfterSave = await page.evaluate( () => document.querySelectorAll( '.minn-pvar-new' ).length );
 		t.check( 'a saved variation is no longer badged new', badgesAfterSave === 0, String( badgesAfterSave ) );
@@ -272,6 +355,7 @@ const { BASE, launch, login, reporter } = require( './helpers' );
 			! ( await page.$( '#minn-p-variations' ) ), '' );
 	} finally {
 		if ( id ) await api( `wc/v3/products/${ id }?force=true`, { method: 'DELETE' } ).catch( () => null );
+		if ( rivalId ) await api( `wc/v3/products/${ rivalId }?force=true`, { method: 'DELETE' } ).catch( () => null );
 	}
 
 	await t.done( browser, errors );

--- a/tests/product-variations.test.js
+++ b/tests/product-variations.test.js
@@ -76,7 +76,7 @@ const { BASE, launch, login, reporter } = require( './helpers' );
 		await page.waitForSelector( '#minn-p-variations', { timeout: 20000 } );
 
 		const card = await page.evaluate( () => ( {
-			titles: Array.from( document.querySelectorAll( '.minn-order-panel .minn-side-title' ) ).map( ( e ) => e.textContent.trim() ),
+			titles: Array.from( document.querySelectorAll( '.minn-order-sec .minn-side-title' ) ).map( ( e ) => e.textContent.trim() ),
 			empty: /No variations yet/.test( ( document.querySelector( '#minn-p-variations' ) || {} ).textContent || '' ),
 			gen: !! document.querySelector( '#minn-p-var-gen' ),
 			add: !! document.querySelector( '#minn-p-var-add' ),
@@ -111,6 +111,10 @@ const { BASE, launch, login, reporter } = require( './helpers' );
 			JSON.stringify( list.map( ( v ) => v.attributes ) ) );
 
 		// Saving twice must not duplicate: created rows come back with ids.
+		// The second save needs a real edit to reach: the page's save bar is
+		// down while the form matches what was stored, which is also the point
+		// of the check — the rows that come back carry ids, so this updates.
+		await page.fill( '[data-pvarreg="0"]', '19.50' );
 		await save();
 		const again = await api( `wc/v3/products/${ id }/variations?per_page=100&_fields=id` );
 		t.check( 'saving twice does not duplicate the variations',


### PR DESCRIPTION
Closes #23.

Eleven commits on top of v0.30.0, each one shippable on its own. Only the
product page is touched: `assets/js/app.js`, `assets/css/app.css`,
`docs/woocommerce-products.md` and the product suites. No REST changes and no
new endpoints.

## The shape

`👌 IMPROVE: Give the product page the order page's Shopify shape`

Cards on a main column plus a 340px sidebar, the grid the order page already
has. Main is what the product IS, the sidebar is what it is FILED UNDER. The
grid lives in the page's stylesheet, so the quick-view modal takes the identical
markup and stacks it: still one body, two hosts.

The page carries a sticky save bar with Discard beside Save. It rides a
fingerprint of `buildProductPayload()` rather than a dirty flag per control,
which is why it cannot drift from what the save actually sends, and why
cancelling out of a picker leaves it down. Controls whose clicks never reach the
body (the media picker, the date picker) tell it themselves. Discard rebuilds
from a copy taken at load: `m.full` is not that copy, because flipping the type
harvests the form into it on purpose.

The body is no longer wrapped in a card. An `overflow: hidden` wrapper would
become the sticky bar's containing block and the bar would stick to nothing.

## The cards

`👌 IMPROVE: Make Variations a list of variants, each with its own editor`

A row per variant: picture, name, price, available, plus a New badge while it is
not on the server yet. Everything modifiable moved into the variant's editor,
including the per-variation picture, which was never here. The editor works on a
copy so Cancel is a real cancel; the batch still rides the page's single Save.

`👌 IMPROVE: Open the taxonomy fields into a checkable list`
`📦 NEW: Add a category, tag or brand from a dialog`

The fields drop a list on focus with a tick box per row, and a row toggles
without closing. Typing still searches the server; the first page is cached per
taxonomy. Add new opens a dialog, which is what makes the door reasonable for a
hierarchy too: the objection was never creating a category, it was creating one
by ACCIDENT, and Enter-to-create still refuses one. The dialog asks the question
a hierarchy needs, which is the parent.

Every search now says it is searching, in the slot the chevron occupies so
nothing shifts when the answer lands. Requests carry a generation, so a slow
answer to an earlier keystroke can neither repaint over a newer one nor stop its
spinner.

## The picker

`👌 IMPROVE: Let the gallery picker take several files from the machine`
`📦 NEW: Show what is uploading, and how far along it is`

The upload took `files[0]` and the browse input had no `multiple`, so ten
pictures from a folder meant ten trips through the file dialog. Both paths now
take the whole selection, sequentially (a dozen parallel uploads is how a shared
host answers 503, and the order of the picks is the gallery's order).

The readout is why `uploadMedia()` is the one place in the app that uses
XMLHttpRequest: fetch cannot report REQUEST progress, so a fetch upload can only
ever say "working". It carries the same nonce `api()` does and refreshes and
retries once on a stale one, so a long upload does not fail a session that is
fine.

## The saves that silently did nothing

`🐛 FIX: Refuse a sale price that is not lower, and a SKU already taken`

Both verified against a live store, because neither behaves the way you would
expect:

- A sale price at or above the regular price comes back **200 with the sale
  price dropped**, on a product and on a variation alike. The variant editor and
  the Pricing card now answer before saving.
- A duplicate SKU inside a variations **batch** also comes back 200, with the
  refusal buried in that item (`product_invalid_sku`, and WooCommerce names a
  SKU that is free). This code threw that away, so a save reported success while
  the variation kept its old SKU. It now reaches the reader, with the suggestion.

SKU uniqueness is answered locally only, against the parent and the other
variants, because that is the clash a page can know without a request. Anything
wider is WooCommerce's to judge.

Two more findings are in the doc rather than in code: WooCommerce refuses a
**video** in a product's gallery outright (400
`woocommerce_product_invalid_image_id` for any non-image attachment), so the
picker does not offer one; and a variation's picture clears on `{ id: 0 }`.

## Also

`📦 NEW: Offer a way back to the product from its description` reuses the trail
the order and subscription pages already leave, so the button names where the
reader came from and a deep link shows nothing.

`🐛 FIX: Line the upload readout up with the picker's drop zone` is one CSS rule.

## Tests

Every suite drives a real browser and asserts what WooCommerce **stored**, not
what the DOM showed. The layout checks measure drawn boxes, because markup can
carry every right class name and still paint as one slab if the CSS never lands.

| Suite | Before | After |
|---|---|---|
| `product-page` | 30 | 38 |
| `product-variations` | 18 | 40 |
| `product-organization` | 20 | 36 |
| `product-images` | 15 | 22 |
| `product-linked` | 14 | 16 |
| `product-fields`, `-advanced`, `-types`, `-attributes`, `products`, `ecommerce-create` | | unchanged, all green |

`editor-sidebar`, `content-editor` and `island-images-editor` green too (the
editor gained the back button, the picker changed under them).

Four suites are red on this lab for reasons that predate the branch and are
unrelated to it: `media-flow` (⌘Z on a pasted image), `image-swap` (fixture
images this lab does not have), `date-picker` (its popover covers the Publish
button) and the PHP-prose check inside `i18n-static`. Each was confirmed by
stashing the branch and running against a clean tree.


https://claude.ai/code/session_01CfjEwyj98joS4gY13VjWyQ
