### PR TITLE
🐛 FIX: Install a newer zip instead of asking to replace it

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -36557,8 +36557,12 @@
 			fd.append( 'file', f );
 			if ( overwrite ) fd.append( 'overwrite', '1' );
 			try {
-				await api( 'minn-admin/v1/themes/upload', { method: 'POST', body: fd } );
-				toast( overwrite ? __( 'Theme replaced with the uploaded version' ) : __( 'Theme installed — activate it from the Themes tab' ) );
+				const r = await api( 'minn-admin/v1/themes/upload', { method: 'POST', body: fd } );
+				const up = r && r.updated;
+				toast( up
+					/* translators: 1: the theme's name. 2: the version that was installed. 3: the version now installed. */
+					? sprintf( __( '%1$s updated from %2$s to %3$s' ), up.name, up.from, up.to )
+					: ( overwrite ? __( 'Theme replaced with the uploaded version' ) : __( 'Theme installed — activate it from the Themes tab' ) ) );
 				state.cache.themes = null;
 				closeModal();
 				if ( state.route === 'extensions' ) renderExtensions();
@@ -37150,8 +37154,12 @@
 			fd.append( 'file', f );
 			if ( overwrite ) fd.append( 'overwrite', '1' );
 			try {
-				await api( 'minn-admin/v1/plugins/upload', { method: 'POST', body: fd } );
-				toast( overwrite ? __( 'Plugin replaced with the uploaded version' ) : __( 'Plugin installed — activate it from the list' ) );
+				const r = await api( 'minn-admin/v1/plugins/upload', { method: 'POST', body: fd } );
+				const up = r && r.updated;
+				toast( up
+					/* translators: 1: the plugin's name. 2: the version that was installed. 3: the version now installed. */
+					? sprintf( __( '%1$s updated from %2$s to %3$s' ), up.name, up.from, up.to )
+					: ( overwrite ? __( 'Plugin replaced with the uploaded version' ) : __( 'Plugin installed — activate it from the list' ) ) );
 				state.cache.plugins = null;
 				await loadPlugins().catch( () => {} );
 				closeModal();

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -403,10 +403,13 @@ Customers, and with WooCommerce Subscriptions it gains Subscriptions too.
 ## Managing the site
 
 - **Extensions** — three tabs: Plugins, Themes, and Licenses. Install by
-  search, upload, or dropping a zip on the dialog; uploading a zip of
-  something already installed shows what is installed against what you
-  uploaded and offers to replace it, files swapped, settings and content
-  untouched. Toggle, update and
+  search, upload, or dropping a zip on the dialog. Uploading a zip of
+  something already installed is an update when the zip is newer: it
+  installs over what is there and tells you which version replaced which.
+  A zip carrying the same or an older version stops first and shows what
+  is installed against what you uploaded, so replacing it (files swapped,
+  settings and content untouched) is a decision rather than an accident.
+  Toggle, update and
   delete with plain confirmations. Every plugin and theme card carries an
   Auto pill for WordPress automatic updates, the same setting wp-admin
   manages, and inactive themes offer a Live preview so you can walk the

--- a/includes/class-minn-admin-rest.php
+++ b/includes/class-minn-admin-rest.php
@@ -5339,17 +5339,24 @@ Sent from <a href="' . esc_url( $url ) . '" style="color:#5a4ef0;text-decoration
 			return new WP_Error( 'move_failed', __( 'Could not store the upload.', 'minn-admin' ), array( 'status' => 500 ) );
 		}
 
-		if ( empty( $request['overwrite'] ) ) {
+		$overwrite = ! empty( $request['overwrite'] );
+		$updated   = null;
+		if ( ! $overwrite ) {
 			$offer = self::upload_existing_offer( $package, 'theme' );
-			if ( $offer ) {
+			if ( is_wp_error( $offer ) ) {
 				@unlink( $package ); // phpcs:ignore
 				return $offer;
+			}
+			if ( $offer ) {
+				// A newer version of what is already here: install over it.
+				$overwrite = true;
+				$updated   = $offer;
 			}
 		}
 
 		$skin     = new WP_Ajax_Upgrader_Skin();
 		$upgrader = new Theme_Upgrader( $skin );
-		$result   = $upgrader->install( $package, array( 'overwrite_package' => ! empty( $request['overwrite'] ) ) );
+		$result   = $upgrader->install( $package, array( 'overwrite_package' => $overwrite ) );
 		@unlink( $package ); // phpcs:ignore
 
 		if ( ! $result || is_wp_error( $result ) ) {
@@ -5360,7 +5367,7 @@ Sent from <a href="' . esc_url( $url ) . '" style="color:#5a4ef0;text-decoration
 			$errors = $skin->get_error_messages();
 			return new WP_Error( 'install_failed', $errors ? implode( ' ', (array) $errors ) : __( 'Install failed.', 'minn-admin' ), array( 'status' => 500 ) );
 		}
-		return rest_ensure_response( array( 'installed' => true, 'stylesheet' => $upgrader->theme_info() ? $upgrader->theme_info()->get_stylesheet() : null ) );
+		return rest_ensure_response( array( 'installed' => true, 'stylesheet' => $upgrader->theme_info() ? $upgrader->theme_info()->get_stylesheet() : null, 'updated' => $updated ) );
 	}
 
 	/**
@@ -5540,17 +5547,24 @@ Sent from <a href="' . esc_url( $url ) . '" style="color:#5a4ef0;text-decoration
 			return new WP_Error( 'move_failed', __( 'Could not store the upload.', 'minn-admin' ), array( 'status' => 500 ) );
 		}
 
-		if ( empty( $request['overwrite'] ) ) {
+		$overwrite = ! empty( $request['overwrite'] );
+		$updated   = null;
+		if ( ! $overwrite ) {
 			$offer = self::upload_existing_offer( $package, 'plugin' );
-			if ( $offer ) {
+			if ( is_wp_error( $offer ) ) {
 				@unlink( $package ); // phpcs:ignore
 				return $offer;
+			}
+			if ( $offer ) {
+				// A newer version of what is already here: install over it.
+				$overwrite = true;
+				$updated   = $offer;
 			}
 		}
 
 		$skin     = new WP_Ajax_Upgrader_Skin();
 		$upgrader = new Plugin_Upgrader( $skin );
-		$result   = $upgrader->install( $package, array( 'overwrite_package' => ! empty( $request['overwrite'] ) ) );
+		$result   = $upgrader->install( $package, array( 'overwrite_package' => $overwrite ) );
 		@unlink( $package ); // phpcs:ignore
 
 		if ( ! $result || is_wp_error( $result ) ) {
@@ -5566,20 +5580,26 @@ Sent from <a href="' . esc_url( $url ) . '" style="color:#5a4ef0;text-decoration
 			array(
 				'installed' => true,
 				'plugin'    => $upgrader->plugin_info(),
+				'updated'   => $updated,
 			)
 		);
 	}
 
 	/**
-	 * When an uploaded zip's install fails because its folder already exists,
-	 * answer 409 with what is installed versus what was uploaded, so the
-	 * client can offer wp-admin's "replace current with uploaded" flow. Any
-	 * other failure returns null and the caller's generic error stands.
+	 * Decide what an uploaded zip means for what is already installed, BEFORE
+	 * the upgrader runs. Three answers:
 	 *
-	 * @param WP_Upgrader $upgrader The upgrader that just failed.
-	 * @param mixed       $result   Its install() return value.
-	 * @param string      $kind     'plugin' or 'theme'.
-	 * @return WP_Error|null
+	 * - null: nothing of that name is here, so it is a plain install.
+	 * - array: the package is a NEWER version of what is here. Dropping a
+	 *   fresh build on a site is an update, and asking about it turns the
+	 *   common case into a dialog; the caller installs over it and reports
+	 *   which version replaced which.
+	 * - WP_Error: same or older version, or a version that cannot be read on
+	 *   either side. That is the drag that loses work, so it stops and asks.
+	 *
+	 * @param string $package Local path of the uploaded zip.
+	 * @param string $kind    'plugin' or 'theme'.
+	 * @return array|WP_Error|null
 	 */
 	private static function upload_existing_offer( $package, $kind ) {
 		$new = self::upload_zip_identity( $package, $kind );
@@ -5594,7 +5614,43 @@ Sent from <a href="' . esc_url( $url ) . '" style="color:#5a4ef0;text-decoration
 		} elseif ( ! is_dir( get_theme_root() . '/' . $folder ) ) {
 			return null;
 		}
+
+		$current = self::upload_installed_identity( $kind, $folder );
+		$to      = (string) ( $new['Version'] ?? '' );
+		// An unreadable version on either side is a question, never a guess.
+		if ( '' !== $current['Version'] && '' !== $to && version_compare( $to, $current['Version'], '>' ) ) {
+			return array(
+				'name' => $current['Name'] ? $current['Name'] : (string) ( $new['Name'] ?? $folder ),
+				'from' => $current['Version'],
+				'to'   => $to,
+			);
+		}
 		return self::upload_overwrite_error( $kind, $folder, $new );
+	}
+
+	/**
+	 * Name and version of the plugin or theme occupying a folder.
+	 *
+	 * @param string $kind   'plugin' or 'theme'.
+	 * @param string $folder Directory name under plugins/ or themes/.
+	 * @return array{Name: string, Version: string} Empty strings when unreadable.
+	 */
+	private static function upload_installed_identity( $kind, $folder ) {
+		if ( 'plugin' === $kind ) {
+			foreach ( get_plugins() as $file => $data ) {
+				if ( 0 === strpos( $file, $folder . '/' ) || $file === $folder . '.php' ) {
+					return array(
+						'Name'    => (string) $data['Name'],
+						'Version' => (string) $data['Version'],
+					);
+				}
+			}
+			return array( 'Name' => '', 'Version' => '' );
+		}
+		$theme = wp_get_theme( $folder );
+		return $theme->exists()
+			? array( 'Name' => (string) $theme->get( 'Name' ), 'Version' => (string) $theme->get( 'Version' ) )
+			: array( 'Name' => '', 'Version' => '' );
 	}
 
 	private static function upload_zip_identity( $package, $kind ) {
@@ -5673,23 +5729,9 @@ Sent from <a href="' . esc_url( $url ) . '" style="color:#5a4ef0;text-decoration
 	}
 
 	private static function upload_overwrite_error( $kind, $folder, $new ) {
-		$current_name    = '';
-		$current_version = '';
-		if ( 'plugin' === $kind ) {
-			foreach ( get_plugins() as $file => $data ) {
-				if ( 0 === strpos( $file, $folder . '/' ) || $file === $folder . '.php' ) {
-					$current_name    = (string) $data['Name'];
-					$current_version = (string) $data['Version'];
-					break;
-				}
-			}
-		} else {
-			$theme = wp_get_theme( $folder );
-			if ( $theme->exists() ) {
-				$current_name    = (string) $theme->get( 'Name' );
-				$current_version = (string) $theme->get( 'Version' );
-			}
-		}
+		$current         = self::upload_installed_identity( $kind, $folder );
+		$current_name    = $current['Name'];
+		$current_version = $current['Version'];
 		return new WP_Error(
 			'folder_exists',
 			/* translators: %s: the installed plugin or theme's name. */
@@ -5704,14 +5746,22 @@ Sent from <a href="' . esc_url( $url ) . '" style="color:#5a4ef0;text-decoration
 	}
 
 	private static function upload_overwrite_offer( $upgrader, $result, $kind ) {
-		$err = is_wp_error( $result ) ? $result : ( isset( $upgrader->result ) && is_wp_error( $upgrader->result ) ? $upgrader->result : null );
-		if ( ( ! $err || 'folder_exists' !== $err->get_error_code() ) && isset( $upgrader->skin ) && method_exists( $upgrader->skin, 'get_errors' ) ) {
-			$skin_err = $upgrader->skin->get_errors();
-			if ( is_wp_error( $skin_err ) && $skin_err->has_errors() && 'folder_exists' === $skin_err->get_error_code() ) {
-				$err = $skin_err;
+		$err = null;
+		// get_error_code() answers with the FIRST code only, and the skin
+		// collects every error a run produced. Asking it for the first one is
+		// how a folder clash behind any other complaint reached the reader as
+		// the raw "Destination folder already exists." with a server path.
+		foreach ( array(
+			$result,
+			isset( $upgrader->result ) ? $upgrader->result : null,
+			isset( $upgrader->skin ) && method_exists( $upgrader->skin, 'get_errors' ) ? $upgrader->skin->get_errors() : null,
+		) as $candidate ) {
+			if ( is_wp_error( $candidate ) && in_array( 'folder_exists', $candidate->get_error_codes(), true ) ) {
+				$err = $candidate;
+				break;
 			}
 		}
-		if ( ! $err || 'folder_exists' !== $err->get_error_code() ) {
+		if ( ! $err ) {
 			return null;
 		}
 		$folder = basename( untrailingslashit( (string) $err->get_error_data( 'folder_exists' ) ) );

--- a/tests/lib/zip.js
+++ b/tests/lib/zip.js
@@ -1,0 +1,164 @@
+/**
+ * A minimal zip writer, so a suite can build a real plugin or theme package on
+ * disk and hand it to the installer the way a person hands it a download.
+ *
+ * Entries are STORED (method 0), never deflated: WordPress unzips through
+ * ZipArchive or PclZip and both read stored entries, while writing a correct
+ * deflate stream here would buy nothing but a smaller file. Everything a test
+ * package holds is a few hundred bytes of PHP.
+ *
+ * No dependency and no build step, matching the rest of tests/.
+ */
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+// CRC-32 (IEEE), table built once. The zip central directory stores it per
+// entry and PclZip verifies it, so an approximation is not an option.
+const CRC_TABLE = ( () => {
+	const table = new Int32Array( 256 );
+	for ( let i = 0; i < 256; i++ ) {
+		let c = i;
+		for ( let k = 0; k < 8; k++ ) {
+			c = c & 1 ? 0xedb88320 ^ ( c >>> 1 ) : c >>> 1;
+		}
+		table[ i ] = c;
+	}
+	return table;
+} )();
+
+function crc32( buf ) {
+	let c = -1;
+	for ( let i = 0; i < buf.length; i++ ) {
+		c = CRC_TABLE[ ( c ^ buf[ i ] ) & 0xff ] ^ ( c >>> 8 );
+	}
+	return ( c ^ -1 ) >>> 0;
+}
+
+// A fixed DOS timestamp (2026-01-01 00:00) keeps two builds of the same files
+// byte-identical, which is one less thing to explain when a test flakes.
+const DOS_TIME = 0;
+const DOS_DATE = ( ( 2026 - 1980 ) << 9 ) | ( 1 << 5 ) | 1;
+
+/**
+ * Write a zip holding the given entries.
+ *
+ * @param {string} zipPath Destination file.
+ * @param {Object} files   Map of path inside the zip => file contents (string).
+ * @return {string} zipPath, for chaining.
+ */
+function writeZip( zipPath, files ) {
+	const locals = [];
+	const central = [];
+	let offset = 0;
+
+	for ( const name of Object.keys( files ) ) {
+		const nameBuf = Buffer.from( name, 'utf8' );
+		const data = Buffer.from( files[ name ], 'utf8' );
+		const crc = crc32( data );
+
+		const local = Buffer.alloc( 30 );
+		local.writeUInt32LE( 0x04034b50, 0 );
+		local.writeUInt16LE( 20, 4 ); // version needed
+		local.writeUInt16LE( 0, 6 ); // flags
+		local.writeUInt16LE( 0, 8 ); // method: stored
+		local.writeUInt16LE( DOS_TIME, 10 );
+		local.writeUInt16LE( DOS_DATE, 12 );
+		local.writeUInt32LE( crc, 14 );
+		local.writeUInt32LE( data.length, 18 );
+		local.writeUInt32LE( data.length, 22 );
+		local.writeUInt16LE( nameBuf.length, 26 );
+		local.writeUInt16LE( 0, 28 ); // extra length
+		locals.push( local, nameBuf, data );
+
+		const entry = Buffer.alloc( 46 );
+		entry.writeUInt32LE( 0x02014b50, 0 );
+		entry.writeUInt16LE( 20, 4 ); // version made by
+		entry.writeUInt16LE( 20, 6 ); // version needed
+		entry.writeUInt16LE( 0, 8 );
+		entry.writeUInt16LE( 0, 10 );
+		entry.writeUInt16LE( DOS_TIME, 12 );
+		entry.writeUInt16LE( DOS_DATE, 14 );
+		entry.writeUInt32LE( crc, 16 );
+		entry.writeUInt32LE( data.length, 20 );
+		entry.writeUInt32LE( data.length, 24 );
+		entry.writeUInt16LE( nameBuf.length, 28 );
+		entry.writeUInt16LE( 0, 30 ); // extra
+		entry.writeUInt16LE( 0, 32 ); // comment
+		entry.writeUInt16LE( 0, 34 ); // disk number
+		entry.writeUInt16LE( 0, 36 ); // internal attrs
+		entry.writeUInt32LE( 0, 38 ); // external attrs
+		entry.writeUInt32LE( offset, 42 );
+		central.push( entry, nameBuf );
+
+		offset += local.length + nameBuf.length + data.length;
+	}
+
+	const body = Buffer.concat( locals );
+	const dir = Buffer.concat( central );
+	const end = Buffer.alloc( 22 );
+	end.writeUInt32LE( 0x06054b50, 0 );
+	end.writeUInt16LE( 0, 4 );
+	end.writeUInt16LE( 0, 6 );
+	end.writeUInt16LE( Object.keys( files ).length, 8 );
+	end.writeUInt16LE( Object.keys( files ).length, 10 );
+	end.writeUInt32LE( dir.length, 12 );
+	end.writeUInt32LE( body.length, 16 );
+	end.writeUInt16LE( 0, 20 );
+
+	fs.mkdirSync( path.dirname( zipPath ), { recursive: true } );
+	fs.writeFileSync( zipPath, Buffer.concat( [ body, dir, end ] ) );
+	return zipPath;
+}
+
+/**
+ * Build a one-file plugin package at the given version.
+ *
+ * The zip carries a single top-level directory, which is what
+ * Plugin_Upgrader::check_package() insists on, and a header block complete
+ * enough for get_plugin_data() to read a name and a version out of it.
+ *
+ * @param {string} zipPath Destination file.
+ * @param {Object} opts    { slug, name, version }.
+ * @return {string} zipPath.
+ */
+function writePluginZip( zipPath, { slug, name, version } ) {
+	const php = `<?php
+/**
+ * Plugin Name: ${ name }
+ * Description: Throwaway package built by Minn Admin's test suite.
+ * Version: ${ version }
+ * Author: Minn Admin tests
+ */
+
+// Deliberately inert: the suite installs and replaces this, never runs it for
+// behaviour of its own.
+`;
+	return writeZip( zipPath, { [ `${ slug }/${ slug }.php` ]: php } );
+}
+
+/**
+ * Build a bare theme package at the given version.
+ *
+ * Theme_Upgrader::check_package() wants a style.css carrying a Theme Name,
+ * and an index.php for anything that is not a child theme. Both are here and
+ * nothing else is.
+ *
+ * @param {string} zipPath Destination file.
+ * @param {Object} opts    { slug, name, version }.
+ * @return {string} zipPath.
+ */
+function writeThemeZip( zipPath, { slug, name, version } ) {
+	const css = `/*
+Theme Name: ${ name }
+Description: Throwaway package built by Minn Admin's test suite.
+Version: ${ version }
+Author: Minn Admin tests
+*/
+`;
+	return writeZip( zipPath, {
+		[ `${ slug }/style.css` ]: css,
+		[ `${ slug }/index.php` ]: "<?php\n// Inert: the suite installs and replaces this, never renders it.\n",
+	} );
+}
+
+module.exports = { writeZip, writePluginZip, writeThemeZip, crc32 };

--- a/tests/plugin-upload-replace.test.js
+++ b/tests/plugin-upload-replace.test.js
@@ -1,0 +1,255 @@
+/**
+ * Uploading a plugin zip whose folder is already there.
+ *
+ * A newer version is an UPDATE and goes through without a question: that is
+ * what dropping a fresh build on a site is for. Only an equal or older version
+ * is worth stopping for, because that is the drag that loses work.
+ *
+ * The suite builds its own throwaway packages (tests/lib/zip.js) and asserts
+ * the version WordPress ended up holding, not what the screen said.
+ */
+const fs = require( 'fs' );
+const os = require( 'os' );
+const path = require( 'path' );
+const { launch, login, reporter, BASE } = require( './helpers' );
+const { writePluginZip, writeThemeZip } = require( './lib/zip' );
+
+// A slug per run, not a fixed one. On a WordPress Playground lab, deleting a
+// plugin leaves a phantom directory behind: PHP's is_dir() says it is gone
+// while WP_Filesystem still finds it, so the next install of the SAME folder
+// dies inside move_dir() with "The destination directory already exists and
+// could not be removed" — a lab ghost that reads exactly like a regression.
+// A fresh folder each run steps around it and costs nothing anywhere else.
+const STAMP = Date.now().toString( 36 ).slice( -6 );
+const SLUG = `minn-lab-dummy-${ STAMP }`;
+const NAME = `Minn Lab Dummy ${ STAMP }`;
+const TSLUG = `minn-lab-skin-${ STAMP }`;
+const TNAME = `Minn Lab Skin ${ STAMP }`;
+
+( async () => {
+	const t = reporter( 'plugin-upload-replace' );
+	const { browser, page, errors } = await launch();
+	await login( page );
+
+	// Both install dialogs search the WordPress.org directory as they open.
+	// Answering it here pins the dialog's second render to a known moment
+	// (see settle() below) and keeps the suite honest on a lab that cannot
+	// reach wordpress.org at all. Nothing here tests the catalog.
+	const noResults = ( route ) =>
+		route.fulfill( { status: 200, contentType: 'application/json', body: '{"plugins":[],"themes":[],"total":0}' } );
+	await page.route( '**/minn-admin/v1/plugins/search*', noResults );
+	await page.route( '**/minn-admin/v1/themes/search*', noResults );
+
+	const tmp = fs.mkdtempSync( path.join( os.tmpdir(), 'minn-pkg-' ) );
+	const zipAt = ( version ) =>
+		writePluginZip( path.join( tmp, `${ SLUG }-${ version }.zip` ), { slug: SLUG, name: NAME, version } );
+
+	// Everything about the installed copy comes from WordPress itself.
+	const installed = () => page.evaluate( async ( file ) => {
+		const r = await fetch( window.MINN.restUrl + 'wp/v2/plugins/' + file, {
+			headers: { 'X-WP-Nonce': window.MINN.nonce },
+		} );
+		if ( ! r.ok ) return null;
+		const j = await r.json();
+		return { version: j.version, status: j.status };
+	}, SLUG + '/' + SLUG );
+
+	const setStatus = ( status ) => page.evaluate( async ( a ) => {
+		await fetch( window.MINN.restUrl + 'wp/v2/plugins/' + a.file, {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json', 'X-WP-Nonce': window.MINN.nonce },
+			body: JSON.stringify( { status: a.status } ),
+		} ).catch( () => {} );
+	}, { file: SLUG + '/' + SLUG, status } );
+
+	const removePlugin = async () => {
+		await setStatus( 'inactive' );
+		await page.evaluate( async ( file ) => {
+			await fetch( window.MINN.restUrl + 'wp/v2/plugins/' + file, {
+				method: 'DELETE',
+				headers: { 'X-WP-Nonce': window.MINN.nonce },
+			} ).catch( () => {} );
+		}, SLUG + '/' + SLUG );
+	};
+
+	/**
+	 * Wait until a node stops being replaced under us.
+	 *
+	 * Stubbing the search above makes the dialog's second render land fast,
+	 * but it still lands. Hand the file input a file while it is happening
+	 * and the file uploads TWICE: Playwright retries an action whose element
+	 * detached, the retry hits the fresh input, and one drop becomes two
+	 * requests (and two dialogs). Marking the node and requiring the mark to
+	 * survive a quiet stretch is the cheap way to know the render is over.
+	 */
+	const settle = async ( sel, quietMs = 1500 ) => {
+		let quietFrom = 0;
+		for ( let i = 0; i < 60; i++ ) {
+			const same = await page.evaluate( ( s ) => {
+				const el = document.querySelector( s );
+				if ( ! el ) return false;
+				if ( el.__minnSettled ) return true;
+				el.__minnSettled = 1;
+				return false;
+			}, sel );
+			if ( ! same ) {
+				quietFrom = 0;
+			} else if ( ! quietFrom ) {
+				quietFrom = Date.now();
+			} else if ( Date.now() - quietFrom >= quietMs ) {
+				return;
+			}
+			await page.waitForTimeout( 200 );
+		}
+	};
+
+	const openAddPlugin = async () => {
+		await page.goto( BASE + '/minn-admin/extensions', { waitUntil: 'domcontentloaded' } );
+		await page.waitForSelector( '#minn-add-plugin', { timeout: 20000 } );
+		await page.click( '#minn-add-plugin' );
+		await page.waitForSelector( '#minn-pi-dropzone', { timeout: 15000 } );
+		await settle( '#minn-pi-file' );
+	};
+
+	/**
+	 * Hand a zip to the installer and report which of the two doors it took:
+	 * 'confirm' (the replace question is up) or 'done' (the modal closed on a
+	 * finished install). Returns 'stuck' if neither happens.
+	 */
+	const upload = async ( zip ) => {
+		await openAddPlugin();
+		await page.setInputFiles( '#minn-pi-file', zip );
+		return Promise.race( [
+			page.waitForSelector( '.minn-confirm-overlay', { timeout: 30000 } ).then( () => 'confirm' ),
+			page.waitForSelector( '#minn-pi-dropzone', { state: 'detached', timeout: 30000 } ).then( () => 'done' ),
+		] ).catch( () => 'stuck' );
+	};
+
+	const themeZipAt = ( version ) =>
+		writeThemeZip( path.join( tmp, `${ TSLUG }-${ version }.zip` ), { slug: TSLUG, name: TNAME, version } );
+
+	const themeVersion = () => page.evaluate( async ( slug ) => {
+		const r = await fetch( window.MINN.restUrl + 'minn-admin/v1/themes', {
+			headers: { 'X-WP-Nonce': window.MINN.nonce },
+		} );
+		if ( ! r.ok ) return null;
+		const found = ( ( await r.json() ).themes || [] ).find( ( x ) => x.stylesheet === slug );
+		return found ? found.version : null;
+	}, TSLUG );
+
+	const removeTheme = () => page.evaluate( async ( slug ) => {
+		await fetch( window.MINN.restUrl + 'minn-admin/v1/themes/delete', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', 'X-WP-Nonce': window.MINN.nonce },
+			body: JSON.stringify( { stylesheet: slug } ),
+		} ).catch( () => {} );
+	}, TSLUG );
+
+	const uploadTheme = async ( zip ) => {
+		await page.goto( BASE + '/minn-admin/extensions', { waitUntil: 'domcontentloaded' } );
+		await page.waitForSelector( '[data-xtab="themes"]', { timeout: 20000 } );
+		await page.click( '[data-xtab="themes"]' );
+		await page.waitForSelector( '#minn-add-theme', { timeout: 15000 } );
+		await page.click( '#minn-add-theme' );
+		await page.waitForSelector( '#minn-ti-dropzone', { timeout: 15000 } );
+		await settle( '#minn-ti-file' );
+		await page.setInputFiles( '#minn-ti-file', zip );
+		return Promise.race( [
+			page.waitForSelector( '.minn-confirm-overlay', { timeout: 30000 } ).then( () => 'confirm' ),
+			page.waitForSelector( '#minn-ti-dropzone', { state: 'detached', timeout: 30000 } ).then( () => 'done' ),
+		] ).catch( () => 'stuck' );
+	};
+
+	const confirmText = () => page.evaluate( () => {
+		const el = document.querySelector( '.minn-confirm-modal' );
+		return el ? el.textContent.replace( /\s+/g, ' ' ) : '';
+	} );
+
+	const answerConfirm = async ( accept, zone = '#minn-pi-dropzone' ) => {
+		await page.click( `.minn-confirm-overlay [data-${ accept ? 'ok' : 'cancel' }]` );
+		if ( accept ) {
+			// Replacing runs a second upload; the dialog it belongs to closes
+			// when that one lands.
+			await page.waitForSelector( zone, { state: 'detached', timeout: 30000 } ).catch( () => {} );
+		}
+		await page.waitForSelector( '.minn-confirm-overlay', { state: 'detached', timeout: 10000 } ).catch( () => {} );
+	};
+
+	const toastText = () => page.evaluate( () =>
+		Array.from( document.querySelectorAll( '.minn-toast' ) ).map( ( el ) => el.textContent ).join( ' | ' )
+	);
+
+	try {
+		await removePlugin();
+
+		/* ===== A folder that is not there installs, as it always did ===== */
+		let door = await upload( zipAt( '1.0.0' ) );
+		t.check( 'a first install asks nothing', door === 'done', door );
+		let now = await installed();
+		t.check( 'the first version is the one installed', now && now.version === '1.0.0', JSON.stringify( now ) );
+
+		await setStatus( 'active' );
+		now = await installed();
+		t.check( 'the plugin is active before the update', now && now.status === 'active', JSON.stringify( now ) );
+
+		/* ===== A NEWER zip is an update, not a question ===== */
+		door = await upload( zipAt( '1.1.0' ) );
+		t.check( 'a newer version installs without a question', door === 'done', door );
+		const updateToast = await toastText();
+		t.check( 'the toast names both versions', /1\.0\.0/.test( updateToast ) && /1\.1\.0/.test( updateToast ), updateToast );
+		now = await installed();
+		t.check( 'WordPress holds the newer version', now && now.version === '1.1.0', JSON.stringify( now ) );
+		t.check( 'the update left it active', now && now.status === 'active', JSON.stringify( now ) );
+
+		/* ===== An OLDER zip stops and names both versions ===== */
+		door = await upload( zipAt( '0.9.0' ) );
+		t.check( 'an older version asks first', door === 'confirm', door );
+		const asked = await confirmText();
+		t.check( 'the question names the installed version', /1\.1\.0/.test( asked ), asked );
+		t.check( 'the question names the uploaded version', /0\.9\.0/.test( asked ), asked );
+
+		await answerConfirm( false );
+		now = await installed();
+		t.check( 'cancelling changes nothing', now && now.version === '1.1.0', JSON.stringify( now ) );
+
+		/* ===== …and replaces when the reader says so ===== */
+		door = await upload( zipAt( '0.9.0' ) );
+		t.check( 'the question comes back on a second try', door === 'confirm', door );
+		await answerConfirm( true );
+		now = await installed();
+		t.check( 'Replace really downgrades the files', now && now.version === '0.9.0', JSON.stringify( now ) );
+		t.check( 'the replace left it active', now && now.status === 'active', JSON.stringify( now ) );
+
+		/* ===== The SAME version is not an update either ===== */
+		door = await upload( zipAt( '0.9.0' ) );
+		t.check( 'the same version still asks', door === 'confirm', door );
+		await answerConfirm( false );
+
+		/* ===== Themes ride the same rule ===== */
+		await removeTheme();
+		door = await uploadTheme( themeZipAt( '0.9.0' ) );
+		t.check( 'a first theme install asks nothing', door === 'done', door );
+		let tv = await themeVersion();
+		t.check( 'the theme is installed', tv === '0.9.0', String( tv ) );
+
+		door = await uploadTheme( themeZipAt( '1.0.0' ) );
+		t.check( 'a newer theme installs without a question', door === 'done', door );
+		const themeToast = await toastText();
+		t.check( 'the theme toast names both versions', /0\.9\.0/.test( themeToast ) && /1\.0\.0/.test( themeToast ), themeToast );
+		tv = await themeVersion();
+		t.check( 'WordPress holds the newer theme', tv === '1.0.0', String( tv ) );
+
+		door = await uploadTheme( themeZipAt( '0.8.0' ) );
+		t.check( 'an older theme asks first', door === 'confirm', door );
+		const askedTheme = await confirmText();
+		t.check( 'the theme question names both versions', /1\.0\.0/.test( askedTheme ) && /0\.8\.0/.test( askedTheme ), askedTheme );
+		await answerConfirm( false, '#minn-ti-dropzone' );
+		tv = await themeVersion();
+		t.check( 'cancelling leaves the theme alone', tv === '1.0.0', String( tv ) );
+	} finally {
+		await removePlugin().catch( () => {} );
+		await removeTheme().catch( () => {} );
+		fs.rmSync( tmp, { recursive: true, force: true } );
+	}
+	await t.done( browser, errors );
+} )();


### PR DESCRIPTION
Closes #29.

One commit on top of v0.31.0. It touches the two upload endpoints, two toast
lines, the user guide, and adds a suite. No new endpoints; the only REST change
is an added `updated` key on the two success replies.

## Newer is an update

`upload_existing_offer()` already reads the zip's name and version before the
upgrader runs, so it now compares them with what occupies the folder:

- **strictly newer** → installs over it (`overwrite_package => true`) and
  returns `updated: { name, from, to }`, so the toast says
  "Akismet updated from 5.3 to 5.7" instead of "Plugin installed";
- **same, older, or unreadable on either side** → the 409 and the dialog it
  already had. An unreadable version is a question rather than a guess, so a
  header Minn cannot parse never silently overwrites anything.

The name/version lookup for the installed copy moved out of
`upload_overwrite_error()` into `upload_installed_identity()`, which both paths
now share; that is most of the diff's line count.

Themes ride the same helper, so `upload_theme()` gets the same behaviour from
the same three lines.

## The folder clash that escaped its own dialog

`upload_overwrite_offer()` asked the skin for `get_error_code()`, which answers
with the FIRST code only. `WP_Ajax_Upgrader_Skin` collects every error a run
produced, so a `folder_exists` sitting behind any other complaint fell past the
offer and reached the reader as core's raw "Destination folder already exists."
with a server path attached. It reads `get_error_codes()` now.

## Tests

`tests/plugin-upload-replace.test.js` (24) drives a real Chrome and asserts the
version WordPress **stored**, not what the screen showed: install 1.0.0 and
activate it, upload 1.1.0 (updates unasked, toast names both versions, stays
active), upload 0.9.0 (asks, names both versions; Cancel keeps 1.1.0; Replace
really downgrades and stays active), upload the same version again (still
asks), then the same walk on a theme.

It builds its own packages: `tests/lib/zip.js` writes stored-entry zips with no
dependency, which is also the only way this suite can assert anything about
version comparison without a fixture to install.

Two lab facts are recorded at their sites in the suite, because both read
exactly like a regression:

- WordPress Playground leaves a phantom directory behind when a plugin is
  deleted (`is_dir()` says gone, `WP_Filesystem` still finds it), so
  reinstalling the SAME folder dies inside `move_dir()`. The suite uses a slug
  per run.
- Handing the file input a file while the install dialog re-renders (its
  directory search landing) uploads it TWICE, because Playwright retries an
  action whose element detached. The suite stubs the search and waits for the
  input node to stop being replaced.

Run against a Playground lab (WP latest, PHP 8.3): the new suite 24/24 twice in
a row, `install-drop` 18/18, `plugin-catalog` 20/20, `plugin-update-queue` 9/9,
`appearance` 19/19.

Red on that lab for want of fixtures it does not have, each confirmed identical
by running the same suite against `main`: `extensions` (wp.org icons and a
theme install), `plugin-names`, `plugin-status-admin`, `visibility-plugins`,
`contract`, `auto-updates` 12/13 (Gravity Forms), `boot-status` 18/19
(WooCommerce), `system` 47/48 (a backup plugin), and the two standing
`i18n-static` reds.

https://claude.ai/code/session_01CfjEwyj98joS4gY13VjWyQ
